### PR TITLE
README: remove redundant JSON key (postData)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ This is the same as `request.get` but it takes one more param:
 
 Parameter | Notes
 |--|--|
-postData | Must be a string with `application/x-www-form-urlencoded`. Eg: `postData": "a=b&c=d"`
+postData | Must be a string with `application/x-www-form-urlencoded`. Eg: `a=b&c=d`
 
 ## Environment variables
 


### PR DESCRIPTION
I apologize for the short PR, but I'd like to suggest removing the redundant JSON key from this section as it might cause confusion.

Alternatively, the following syntax could be used as to reduce ambiguity:
```json
{
  "postData": "a=b&c=d"
}
```

In any case, the missing double quotes in the beginning of the JSON key in the original README file is not valid.