### PR TITLE
gotoPage 2000ms navigation timeout is too short

### DIFF
--- a/src/services/solver.ts
+++ b/src/services/solver.ts
@@ -139,7 +139,7 @@ async function gotoPage(params: V1Request, page: Page): Promise<HTTPResponse> {
         response = await page.goto(params.url, {waitUntil: 'domcontentloaded', timeout: pageTimeout});
     } catch (e) {
         // retry
-        response = await page.goto(params.url, {waitUntil: 'domcontentloaded', timeout: 2000});
+        response = await page.goto(params.url, {waitUntil: 'domcontentloaded', timeout: pageTimeout});
     }
 
     if (params.method == 'POST') {
@@ -184,9 +184,9 @@ async function gotoPage(params: V1Request, page: Page): Promise<HTTPResponse> {
 </html> 
             `
         );
-        await page.waitForTimeout(2000)
+        await page.waitForTimeout(pageTimeout)
         try {
-            await page.waitForNavigation({waitUntil: 'domcontentloaded', timeout: 2000})
+            await page.waitForNavigation({waitUntil: 'domcontentloaded', timeout: pageTimeout})
         } catch (e) {}
 
     }


### PR DESCRIPTION
The 2000ms navigation timeout is very short (even the puppeteer default is 30 seconds!). The heuristic of params.maxTimeout/3 sounds reasonable, so lets use it everywhere?