### PR TITLE
Fix ban detection for Yggtorrent

### DIFF
--- a/src/providers/cloudflare.ts
+++ b/src/providers/cloudflare.ts
@@ -37,7 +37,13 @@ export default async function resolveChallenge(url: string, page: Page, response
   }
 
   if (await findAnySelector(page, BAN_SELECTORS)) {
-    throw new Error('Cloudflare has blocked this request. Probably your IP is banned for this site, check in your web browser.')
+    const errorCodeElem = await page.$(BAN_SELECTORS[0]);
+    if (errorCodeElem) {
+      let displayCSSProperty = await errorCodeElem.evaluate(el => (<HTMLElement>el).style.display);
+      if (displayCSSProperty !== 'none') {
+        throw new Error('Cloudflare has blocked this request. Probably your IP is banned for this site, check in your web browser.');
+      }
+    }
   }
 
   // find Cloudflare selectors


### PR DESCRIPTION
I noticed the following HTML object sometimes being present in the answer from "under-attack" websites:
```html
<span style="display: none;" class="text-gray-600" data-translate="error">error code: 1020</span>
```

It does not seem like a real ban to me, and ignoring this message allows flaresolverr to work.
Hopefully it does not prevent detection of real bans.

Fixes #330 