### PR TITLE
WIP: Support proxy, http status codes and http headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bottle==0.12.23
 waitress==2.1.2
 selenium==4.7.2
+selenium-wire==5.1.0
 func-timeout==4.3.5
 # required by undetected_chromedriver
 requests==2.28.1

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -169,7 +169,7 @@ def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
     timeout = req.maxTimeout / 1000
     driver = None
     try:
-        driver = utils.get_webdriver()
+        driver = utils.get_webdriver(request_info=req)
         return func_timeout(timeout, _evil_logic, (req, driver, method))
     except FunctionTimedOut:
         raise Exception(f'Error solving the challenge. Timeout after {timeout} seconds.')

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,7 +4,9 @@ import os
 import re
 import shutil
 
+import seleniumwire.undetected_chromedriver as sw_uc
 from selenium.webdriver.chrome.webdriver import WebDriver
+
 import undetected_chromedriver as uc
 
 FLARESOLVERR_VERSION = None
@@ -38,7 +40,7 @@ def get_webdriver() -> WebDriver:
     logging.debug('Launching web browser...')
 
     # undetected_chromedriver
-    options = uc.ChromeOptions()
+    options = sw_uc.ChromeOptions()
     options.add_argument('--no-sandbox')
     options.add_argument('--window-size=1920,1080')
     # todo: this param shows a warning in chrome head-full
@@ -69,8 +71,17 @@ def get_webdriver() -> WebDriver:
 
     # downloads and patches the chromedriver
     # if we don't set driver_executable_path it downloads, patches, and deletes the driver each time
-    driver = uc.Chrome(options=options, driver_executable_path=driver_exe_path, version_main=version_main,
-                       windows_headless=windows_headless)
+    # ToDo: seleniumwire supports proxy through seleniumwire_options
+    # sw_options = {
+    #     'proxy': {
+    #         'http': 'http://192.168.10.100:8888',
+    #         'https': 'https://192.168.10.100:8888',
+    #         'no_proxy': 'localhost,127.0.0.1'
+    #     }
+    # }
+    sw_options = {}
+    driver = sw_uc.Chrome(options=options, driver_executable_path=driver_exe_path, version_main=version_main,
+                          windows_headless=windows_headless, seleniumwire_options=sw_options)
 
     # save the patched driver to avoid re-downloads
     if driver_exe_path is None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -35,7 +35,7 @@ def get_flaresolverr_version() -> str:
         return FLARESOLVERR_VERSION
 
 
-def get_webdriver() -> WebDriver:
+def get_webdriver(request_info=False) -> WebDriver:
     global PATCHED_DRIVER_PATH
     logging.debug('Launching web browser...')
 
@@ -69,17 +69,28 @@ def get_webdriver() -> WebDriver:
         if PATCHED_DRIVER_PATH is not None:
             driver_exe_path = PATCHED_DRIVER_PATH
 
+    # seleniumwire supports http or socks proxys (optionally with inline basic auth)
+    # see: https://pypi.org/project/selenium-wire/#proxies
+    proxy_info = None
+    if request_info:
+        try:
+            proxy_info = request_info.proxy
+        except:
+            pass
+
+    sw_options = {}
+    if proxy_info is not None:
+        proxy_url = proxy_info['url']  #
+        sw_options = {
+            'proxy': {
+                'http': proxy_url,
+                'https': proxy_url,
+                'no_proxy': 'localhost,127.0.0.1'
+            }
+        }
+
     # downloads and patches the chromedriver
     # if we don't set driver_executable_path it downloads, patches, and deletes the driver each time
-    # ToDo: seleniumwire supports proxy through seleniumwire_options
-    # sw_options = {
-    #     'proxy': {
-    #         'http': 'http://192.168.10.100:8888',
-    #         'https': 'https://192.168.10.100:8888',
-    #         'no_proxy': 'localhost,127.0.0.1'
-    #     }
-    # }
-    sw_options = {}
     driver = sw_uc.Chrome(options=options, driver_executable_path=driver_exe_path, version_main=version_main,
                           windows_headless=windows_headless, seleniumwire_options=sw_options)
 


### PR DESCRIPTION
I have Python experience, but none with this particular setup of Selenium and the undetected ChromeDriver.

I managed to cobble a working proof of concept together. Still, this PR is for others to pick up and improve.

# Reason for PR: Seleniumwire has proxy support

* requests are intercepted as well:
  - headers are returned (current todo in master)
  - http status codes are returned (current todo in master)

What is working:
- seleniumwire is integrated and accepts the Flaresolverr request
- proxy support is implemented but needs refactor to keep up flaresolverr's code quality
- http status_code is captured and returned
- http_headers are captured and returned

What is not working:
- Request challenges are NOT detected right now, as the request body is empty, for some reason. Maybe the seleniumwire root certificate is broken.
- Proxy support needs more testing with http/socks etc.