### PR TITLE
update ddos-guard title (anidex.info)

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -31,6 +31,8 @@ CHALLENGE_TITLES = [
     'Just a moment...',
     # DDoS-GUARD
     'DDOS-GUARD',
+    # DDoS-Guard https://anidex.info/ Chrome
+    'DDoS-Guard'
 ]
 CHALLENGE_SELECTORS = [
     # Cloudflare

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -30,8 +30,6 @@ CHALLENGE_TITLES = [
     # Cloudflare
     'Just a moment...',
     # DDoS-GUARD
-    'DDOS-GUARD',
-    # DDoS-Guard https://anidex.info/ Chrome
     'DDoS-Guard'
 ]
 CHALLENGE_SELECTORS = [
@@ -215,9 +213,9 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
     # find challenge by title
     challenge_found = False
     for title in CHALLENGE_TITLES:
-        if title == page_title:
+        if title.lower() == page_title.lower():
             challenge_found = True
-            logging.info("Challenge detected. Title found: " + title)
+            logging.info("Challenge detected. Title found: " + page_title)
             break
     if not challenge_found:
         # find challenge by selectors


### PR DESCRIPTION
DDoS-Guard's title is now `DDoS-Guard`, not `DDOS-GUARD`, at least at anidex.info. Without this change, the challenge will not be detected and the DDoS-Guard page is returned immediately.
[anidex.00.log](https://github.com/FlareSolverr/FlareSolverr/files/10661493/anidex.00.log)
I did not remove the old all-caps test because I was unable to trigger a DDoS-Guard challenge on another site that uses DDoS-Guard to check if this is a universal change, something being rolled out, something unique to pages served to Chrome, Chrome on Windows, or some other combination/something else, so instead I added it in using the same commenting syntax as a few lines up, out of an abundance of caution. 
