### PR TITLE
Fix headless mode in mac OS

### DIFF
--- a/src/undetected_chromedriver/__init__.py
+++ b/src/undetected_chromedriver/__init__.py
@@ -372,9 +372,10 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
             options.arguments.extend(["--no-sandbox", "--test-type"])
 
         if headless or options.headless:
-            if self.patcher.version_main < 108:
+            v_main = int(self.patcher.version_main) if self.patcher.version_main else 108
+            if v_main < 108:
                 options.add_argument("--headless=chrome")
-            elif self.patcher.version_main >= 108:
+            elif v_main >= 108:
                 options.add_argument("--headless=new")
 
         options.add_argument("--window-size=1920,1080")


### PR DESCRIPTION
Fixes #710. `version_main` treated as str instead of int, causing comparison failures and preventing headless browser mode. Updated code to treat `version_main` as int for correct comparison and enable headless mode.