### PR TITLE
Captchas not working for windows

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -54,11 +54,13 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     options.add_argument('--disable-software-rasterizer')
     options.add_argument('--ignore-certificate-errors')
     options.add_argument('--ignore-ssl-errors')
+    options.add_argument("--auto-open-devtools-for-tabs")
     # fix GL erros in ASUSTOR NAS
     # https://github.com/FlareSolverr/FlareSolverr/issues/782
     # https://github.com/microsoft/vscode/issues/127800#issuecomment-873342069
     # https://peter.sh/experiments/chromium-command-line-switches/#use-gl
     options.add_argument('--use-gl=swiftshader')
+    options.headless = True
 
     if proxy and 'url' in proxy:
         proxy_url = proxy['url']
@@ -98,6 +100,12 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     if driver_exe_path is None:
         PATCHED_DRIVER_PATH = os.path.join(driver.patcher.data_path, driver.patcher.exe_name)
         shutil.copy(driver.patcher.executable_path, PATCHED_DRIVER_PATH)
+        
+    # open a new tab and close the first one to be able to bypass cloudflare
+    driver.execute_script('''window.open("","_blank");''')
+    driver.switch_to.window(window_name=driver.window_handles[0])
+    driver.close()
+    driver.switch_to.window(window_name=driver.window_handles[0] )
 
     # selenium vanilla
     # options = webdriver.ChromeOptions()

--- a/src/utils.py
+++ b/src/utils.py
@@ -59,7 +59,7 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     # https://github.com/microsoft/vscode/issues/127800#issuecomment-873342069
     # https://peter.sh/experiments/chromium-command-line-switches/#use-gl
     options.add_argument('--use-gl=swiftshader')
-    # workaround for new 'verify your are human' check
+    # workaround for updated 'verify your are human' check
     # https://github.com/FlareSolverr/FlareSolverr/issues/811
     options.add_argument('--auto-open-devtools-for-tabs')
     options.add_argument('--headless=true')
@@ -103,7 +103,8 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
         PATCHED_DRIVER_PATH = os.path.join(driver.patcher.data_path, driver.patcher.exe_name)
         shutil.copy(driver.patcher.executable_path, PATCHED_DRIVER_PATH)
         
-    # open a new tab and close the first one to be able to bypass cloudflare
+    # workaround for updated 'verify your are human' check
+    # https://github.com/FlareSolverr/FlareSolverr/issues/811
     driver.execute_script('''window.open("","_blank");''')
     driver.switch_to.window(window_name=driver.window_handles[0])
     driver.close()

--- a/src/utils.py
+++ b/src/utils.py
@@ -54,13 +54,15 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     options.add_argument('--disable-software-rasterizer')
     options.add_argument('--ignore-certificate-errors')
     options.add_argument('--ignore-ssl-errors')
-    options.add_argument("--auto-open-devtools-for-tabs")
-    # fix GL erros in ASUSTOR NAS
+    # fix GL errors in ASUSTOR NAS
     # https://github.com/FlareSolverr/FlareSolverr/issues/782
     # https://github.com/microsoft/vscode/issues/127800#issuecomment-873342069
     # https://peter.sh/experiments/chromium-command-line-switches/#use-gl
     options.add_argument('--use-gl=swiftshader')
-    options.headless = True
+    # workaround for new 'verify your are human' check
+    # https://github.com/FlareSolverr/FlareSolverr/issues/811
+    options.add_argument('--auto-open-devtools-for-tabs')
+    options.add_argument('--headless=true')
 
     if proxy and 'url' in proxy:
         proxy_url = proxy['url']
@@ -105,7 +107,7 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     driver.execute_script('''window.open("","_blank");''')
     driver.switch_to.window(window_name=driver.window_handles[0])
     driver.close()
-    driver.switch_to.window(window_name=driver.window_handles[0] )
+    driver.switch_to.window(window_name=driver.window_handles[0])
 
     # selenium vanilla
     # options = webdriver.ChromeOptions()


### PR DESCRIPTION
Related to [this issue](https://github.com/FlareSolverr/FlareSolverr/issues/811) and [this pr](https://github.com/FlareSolverr/FlareSolverr/pull/812).

Adding just the devtools or just the opening a new window workaround did not work for me. Doing both of these things together does work! I am running it from the command line on a windows machine.

I had to add `options.Headless = True ` in order to not have the browser window popup.