### PR TITLE
mbakgun/FlareSolverr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.3.1 (2023/08/02)
+
+* Fix for some Linux distributions boot error
+
 ## v3.3.0 (2023/08/02)
 
 * Fix for new Cloudflare detection. Thanks @cedric-bour for #845

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm as builder
+FROM python:3.11-slim-bullseye as builder
 
 # Build dummy packages to skip installing them and their dependencies
 RUN apt-get update \
@@ -12,7 +12,7 @@ RUN apt-get update \
     && equivs-build adwaita-icon-theme \
     && mv adwaita-icon-theme_*.deb /adwaita-icon-theme.deb
 
-FROM python:3.11-slim-bookworm
+FROM python:3.11-slim-bullseye
 
 # Copy dummy packages
 COPY --from=builder /*.deb /
@@ -30,11 +30,9 @@ RUN dpkg -i /libgl1-mesa-dri.deb \
     # Install dependencies
     && apt-get update \
     && apt-get install -y --no-install-recommends chromium chromium-common chromium-driver xvfb dumb-init \
-        procps curl vim-tiny xauth \
+        procps curl vim xauth \
     # Remove temporary files and hardware decoding libraries
     && rm -rf /var/lib/apt/lists/* \
-    && rm -f /usr/lib/systemd/systemd* \
-    && rm -f /usr/lib/x86_64-linux-gnu/systemd/* \
     && rm -f /usr/lib/x86_64-linux-gnu/libmfxhw* \
     && rm -f /usr/lib/x86_64-linux-gnu/mfx/* \
     # Create flaresolverr user

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,17 +62,17 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/usr/local/bin/python", "-u", "/app/flaresolverr.py"]
 
 # Local build
-# docker build -t ngosang/flaresolverr:3.3.0 .
-# docker run -p 8191:8191 ngosang/flaresolverr:3.3.0
+# docker build -t ngosang/flaresolverr:3.3.1 .
+# docker run -p 8191:8191 ngosang/flaresolverr:3.3.1
 
 # Multi-arch build
 # docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 # docker buildx create --use
-# docker buildx build -t ngosang/flaresolverr:3.3.0 --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8 .
+# docker buildx build -t ngosang/flaresolverr:3.3.1 --platform linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8 .
 #   add --push to publish in DockerHub
 
 # Test multi-arch build
 # docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 # docker buildx create --use
-# docker buildx build -t ngosang/flaresolverr:3.3.0 --platform linux/arm/v7 --load .
-# docker run -p 8191:8191 --platform linux/arm/v7 ngosang/flaresolverr:3.3.0
+# docker buildx build -t ngosang/flaresolverr:3.3.1 --platform linux/arm/v7 --load .
+# docker run -p 8191:8191 --platform linux/arm/v7 ngosang/flaresolverr:3.3.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,9 @@ WORKDIR /app
     # Install dummy packages
 RUN dpkg -i /libgl1-mesa-dri.deb \
     && dpkg -i /adwaita-icon-theme.deb \
-    # Use Testing packages. The latest version of Chromium is not available for ARM
-    && sed -i 's/bookworm-updates/bookworm-updates testing/g' /etc/apt/sources.list.d/debian.sources \
     # Install dependencies
     && apt-get update \
-    && apt-get install -y --no-install-recommends -t testing chromium chromium-common chromium-driver xvfb dumb-init \
+    && apt-get install -y --no-install-recommends chromium chromium-common chromium-driver xvfb dumb-init \
         procps curl vim-tiny xauth \
     # Remove temporary files and hardware decoding libraries
     && rm -rf /var/lib/apt/lists/* \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flaresolverr",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Proxy server to bypass Cloudflare protection",
   "author": "Diego Heras (ngosang / ngosang@hotmail.es)",
   "license": "MIT"


### PR DESCRIPTION
Hello,

I encountered a problem with the boot phase of version 3.3.0 which was released today. Upon noticing the [open issue](https://github.com/FlareSolverr/FlareSolverr/issues/849), I was able to set up Flaresolver locally. Reverting these two commits proved successful for me. Additionally, I increased the version to 3.3.1

<img width="1118" alt="Screenshot 2023-08-02 at 9 41 47 PM" src="https://github.com/FlareSolverr/FlareSolverr/assets/8726393/a1844424-aa7b-4b84-9694-bf3b95107084">

Fix comes with  3.3.1 : 

<img width="1415" alt="Screenshot 2023-08-02 at 9 55 10 PM" src="https://github.com/FlareSolverr/FlareSolverr/assets/8726393/2fa68019-bdb5-48cf-a2e3-2b9bcbf7e202">