### PR TITLE
Fix of the subprocess.STARTUPINFO() call.

### DIFF
--- a/src/undetected_chromedriver/__init__.py
+++ b/src/undetected_chromedriver/__init__.py
@@ -451,8 +451,9 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 options.binary_location, *options.arguments
             )
         else:
-            startupinfo = subprocess.STARTUPINFO()
+            startupinfo = None
             if os.name == 'nt' and windows_headless:
+                startupinfo = subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             browser = subprocess.Popen(
                 [options.binary_location, *options.arguments],


### PR DESCRIPTION
The 'subprocess.STARTUPINFO()' call was being made before the OS check, and this was raising an exception in a Linux environment.