### PR TITLE
Remove options.headless which was deprecated in Selenium 4.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bottle==0.12.25
 waitress==2.1.2
-selenium==4.11.2
+selenium==4.15.2
 func-timeout==4.3.5
 prometheus-client==0.17.1
 # required by undetected_chromedriver

--- a/src/undetected_chromedriver/__init__.py
+++ b/src/undetected_chromedriver/__init__.py
@@ -17,7 +17,7 @@ by UltrafunkAmsterdam (https://github.com/ultrafunkamsterdam)
 from __future__ import annotations
 
 
-__version__ = "3.5.3"
+__version__ = "3.5.4"
 
 import json
 import logging
@@ -303,7 +303,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
 
             if any([_ in arg for _ in ("--headless", "headless")]):
                 options.arguments.remove(arg)
-                headless = True
+                options.headless = True
 
             if "lang" in arg:
                 m = re.search("(?:--)?lang(?:[ =])?(.*)", arg)
@@ -396,7 +396,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         if no_sandbox:
             options.arguments.extend(["--no-sandbox", "--test-type"])
 
-        if headless:
+        if headless or getattr(options, 'headless', None):
             #workaround until a better checking is found
             try:
                 v_main = int(self.patcher.version_main) if self.patcher.version_main else 108
@@ -491,7 +491,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         else:
             self._web_element_cls = WebElement
 
-        if headless:
+        if headless or getattr(options, 'headless', None):
             self._configure_headless()
 
     def _configure_headless(self):

--- a/src/undetected_chromedriver/__init__.py
+++ b/src/undetected_chromedriver/__init__.py
@@ -303,7 +303,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
 
             if any([_ in arg for _ in ("--headless", "headless")]):
                 options.arguments.remove(arg)
-                options.headless = True
+                headless = True
 
             if "lang" in arg:
                 m = re.search("(?:--)?lang(?:[ =])?(.*)", arg)
@@ -396,7 +396,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         if no_sandbox:
             options.arguments.extend(["--no-sandbox", "--test-type"])
 
-        if headless or options.headless:
+        if headless:
             #workaround until a better checking is found
             try:
                 v_main = int(self.patcher.version_main) if self.patcher.version_main else 108
@@ -491,7 +491,7 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
         else:
             self._web_element_cls = WebElement
 
-        if options.headless:
+        if headless:
             self._configure_headless()
 
     def _configure_headless(self):

--- a/src/utils.py
+++ b/src/utils.py
@@ -153,7 +153,7 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
         logging.debug("Using webdriver proxy: %s", proxy_url)
         options.add_argument('--proxy-server=%s' % proxy_url)
 
-    # note: headless mode is detected (options.headless = True)
+    # note: headless mode is detected (headless = True)
     # we launch the browser in head-full mode with the window hidden
     windows_headless = False
     if get_config_headless():
@@ -161,6 +161,8 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
             windows_headless = True
         else:
             start_xvfb_display()
+    # For normal headless mode:
+    # options.add_argument('--headless')
 
     # if we are inside the Docker container, we avoid downloading the driver
     driver_exe_path = None


### PR DESCRIPTION
Before this change:

```python
Nov 14 10:14:59 dungeon-of-data flaresolverr[16725]: 2023-11-14 10:14:59 INFO     FlareSolverr 3.3.10
Nov 14 10:14:59 dungeon-of-data flaresolverr[16725]: 2023-11-14 10:14:59 INFO     Testing web browser installation...
Nov 14 10:14:59 dungeon-of-data flaresolverr[16725]: 2023-11-14 10:14:59 INFO     Platform: Linux-6.5.9-zen2-1-zen-x86_64-with-glibc2.38
Nov 14 10:14:59 dungeon-of-data flaresolverr[16725]: 2023-11-14 10:14:59 INFO     Chrome / Chromium path: /usr/bin/chromium
Nov 14 10:14:59 dungeon-of-data flaresolverr[16725]: 2023-11-14 10:14:59 INFO     Chrome / Chromium major version: 119
Nov 14 10:14:59 dungeon-of-data flaresolverr[16725]: 2023-11-14 10:14:59 INFO     Launching web browser...
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]: Traceback (most recent call last):
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:   File "/opt/flaresolverr/utils.py", line 296, in get_user_agent
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:     driver = get_webdriver()
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:              ^^^^^^^^^^^^^^^
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:   File "/opt/flaresolverr/utils.py", line 177, in get_webdriver
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:     driver = uc.Chrome(options=options, browser_executable_path=browser_executable_path,
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:   File "/opt/flaresolverr/undetected_chromedriver/__init__.py", line 399, in __init__
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:     if headless or options.headless:
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:                    ^^^^^^^^^^^^^^^^
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]: AttributeError: 'ChromeOptions' object has no attribute 'headless'
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]: During handling of the above exception, another exception occurred:
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]: Traceback (most recent call last):
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:   File "/opt/flaresolverr/flaresolverr.py", line 105, in <module>
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:     flaresolverr_service.test_browser_installation()
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:   File "/opt/flaresolverr/flaresolverr_service.py", line 72, in test_browser_installation
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:     user_agent = utils.get_user_agent()
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:                  ^^^^^^^^^^^^^^^^^^^^^^
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:   File "/opt/flaresolverr/utils.py", line 302, in get_user_agent
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]:     raise Exception("Error getting browser User-Agent. " + str(e))
Nov 14 10:15:01 dungeon-of-data flaresolverr[16725]: Exception: Error getting browser User-Agent. 'ChromeOptions' object has no attribute 'headless'
Nov 14 10:15:01 dungeon-of-data systemd[1]: flaresolverr.service: Main process exited, code=exited, status=1/FAILURE
```

After this change:
```python
2023-11-14 10:42:58 INFO     FlareSolverr 3.3.10
2023-11-14 10:42:58 INFO     Testing web browser installation...
2023-11-14 10:42:58 INFO     Platform: Linux-6.5.9-zen2-1-zen-x86_64-with-glibc2.38
2023-11-14 10:42:58 INFO     Chrome / Chromium path: /usr/bin/google-chrome-stable
2023-11-14 10:42:58 INFO     Chrome / Chromium major version: 119
2023-11-14 10:42:58 INFO     Launching web browser...
2023-11-14 10:43:01 INFO     FlareSolverr User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
2023-11-14 10:43:01 INFO     Test successful!
2023-11-14 10:43:01 INFO     Serving on http://0.0.0.0:8191
2023-11-14 10:43:36 INFO     Incoming request => POST /v1 body: {'maxTimeout': 55000, 'cmd': 'request.get', 'url': 'https://badasstorrents.com/torrents/search/<snipped>/date/desc', 'proxy': {'url': '127.0.0.1:8080'}}
2023-11-14 10:43:38 INFO     Challenge detected. Title found: Just a moment...
2023-11-14 10:43:43 INFO     Challenge solved!
2023-11-14 10:43:44 INFO     Response in 7.283 s
```

Based on https://github.com/ultrafunkamsterdam/undetected-chromedriver/pull/1602 since it isn't merged into UC yet.