### PR TITLE
Creating a option for user can executing js code

### DIFF
--- a/src/dtos.py
+++ b/src/dtos.py
@@ -18,6 +18,7 @@ class ChallengeResolutionResultT:
 class ChallengeResolutionT:
     status: str = None
     message: str = None
+    jsrespond: str = None
     result: ChallengeResolutionResultT = None
 
     def __init__(self, _dict):
@@ -32,6 +33,7 @@ class V1RequestBase(object):
     cookies: list = None
     maxTimeout: int = None
     proxy: dict = None
+    execjs: str = None
     session: str = None
     session_ttl_minutes: int = None
     headers: list = None  # deprecated v2.0.0, not used

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -395,7 +395,7 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
     challenge_res.userAgent = utils.get_user_agent(driver)
     if req.execjs:
         r = driver.execute_script(req.execjs)
-        res.jsrespond = r
+        challenge_res.jsrespond = r
         logging.info(f"executing {req.execjs} and got an output {r}")
     if not req.returnOnlyCookies:
         challenge_res.headers = {}  # todo: fix, selenium not provides this info

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -393,7 +393,10 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
     challenge_res.status = 200  # todo: fix, selenium not provides this info
     challenge_res.cookies = driver.get_cookies()
     challenge_res.userAgent = utils.get_user_agent(driver)
-
+    if req.execjs:
+        r = driver.execute_script(req.execjs)
+        res.jsrespond = r
+        logging.info(f"executing {req.execjs} and got an output {r}")
     if not req.returnOnlyCookies:
         challenge_res.headers = {}  # todo: fix, selenium not provides this info
         challenge_res.response = driver.page_source


### PR DESCRIPTION
This makes the user scrapping more easy and more custom bypass. sometime the user have another challange in the side and required using javascript to bypass it.

in this example i'm demonstrate it using site that requred DFP and the DFP it gets from the javascript execution in the site directly
in this images i show that if the DFP is wrong or not generate by the js in the site will return a 400 Bad Requests
![image](https://github.com/FlareSolverr/FlareSolverr/assets/113588203/cff78783-7841-4b0c-acf3-55eab7086d03)
But if DFP is correctly generate it will respond 200 OK
and this how to generate DFP from the site :
![image](https://github.com/FlareSolverr/FlareSolverr/assets/113588203/46fc734c-572a-44d1-8a2d-86adbfe7799d)

so to get DFP we need execution javascript in the selenium and in this PR i create a javascript execution by user so user can use custom payload js 