### PR TITLE
add some config envs: CHROME_EXE_PATH PATCHED_DRIVER_PATH PATCHED_DRIVER_IS_PATCHED

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ This is the same as `request.get` but it takes one more param:
 | HOST               | 0.0.0.0                | Listening interface. You don't need to change this if you are running on Docker.                                                                              |
 | PROMETHEUS_ENABLED | false                  | Enable Prometheus exporter. See the Prometheus section below.                                                                                                 |
 | PROMETHEUS_PORT    | 8192                   | Listening port for Prometheus exporter. See the Prometheus section below.                                                                                     |
+| CHROME_EXE_PATH    | none                   | Path to the chrome executable. By default, use the chrome executable from the pyinstaller bundle or from the system PATH. |
+| PATCHED_DRIVER_PATH | none                  | Path to the patched chromedriver executable. By default, `undetected_chromedriver` will store the patched chromedriver executable in [data_path](https://github.com/ultrafunkamsterdam/undetected-chromedriver/blob/master/undetected_chromedriver/patcher.py) in the user's HOME folder. |
+| PATCHED_DRIVER_IS_PATCHED | false           | If `true` then skip patching the chromedriver executable. |
 
 Environment variables are set differently depending on the operating system. Some examples:
 * Docker: Take a look at the Docker section in this document. Environment variables can be set in the `docker-compose.yml` file or in the Docker CLI command.

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -66,7 +66,7 @@ def test_browser_installation():
         logging.error("Chrome / Chromium version not detected!")
         sys.exit(1)
     else:
-        logging.info("Chrome / Chromium major version: " + chrome_major_version)
+        logging.info(f"Chrome / Chromium major version: {chrome_major_version}")
 
     logging.info("Launching web browser...")
     user_agent = utils.get_user_agent()

--- a/src/utils.py
+++ b/src/utils.py
@@ -225,7 +225,7 @@ def get_chrome_exe_path() -> str:
     return CHROME_EXE_PATH
 
 
-def get_chrome_major_version() -> str:
+def get_chrome_major_version() -> int:
     global CHROME_MAJOR_VERSION
     if CHROME_MAJOR_VERSION is not None:
         return CHROME_MAJOR_VERSION
@@ -248,7 +248,7 @@ def get_chrome_major_version() -> str:
         complete_version = process.read()
         process.close()
 
-    CHROME_MAJOR_VERSION = complete_version.split('.')[0].split(' ')[-1]
+    CHROME_MAJOR_VERSION = int(complete_version.split('.')[0].split(' ')[-1])
     return CHROME_MAJOR_VERSION
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -246,6 +246,7 @@ def get_chrome_major_version() -> int:
         # Example 1: 'Chromium 104.0.5112.79 Arch Linux\n'
         # Example 2: 'Google Chrome 104.0.5112.79 Arch Linux\n'
         complete_version = process.read()
+        complete_version = re.findall(r"\d+\.\d+\.\d+\.\d+", complete_version)[0]
         process.close()
 
     CHROME_MAJOR_VERSION = int(complete_version.split('.')[0].split(' ')[-1])

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,11 +10,12 @@ from selenium.webdriver.chrome.webdriver import WebDriver
 import undetected_chromedriver as uc
 
 FLARESOLVERR_VERSION = None
-CHROME_EXE_PATH = None
+CHROME_EXE_PATH = os.environ.get("CHROME_EXE_PATH", None)
 CHROME_MAJOR_VERSION = None
 USER_AGENT = None
 XVFB_DISPLAY = None
-PATCHED_DRIVER_PATH = None
+PATCHED_DRIVER_PATH = os.environ.get("PATCHED_DRIVER_PATH", None)
+PATCHED_DRIVER_IS_PATCHED = re.match(r"true|1", os.environ.get("PATCHED_DRIVER_IS_PATCHED", ""), re.I) != None
 
 
 def get_config_log_html() -> bool:
@@ -162,6 +163,7 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
         else:
             start_xvfb_display()
 
+    # TODO(milahu) remove. instead, docker containers should set the env PATCHED_DRIVER_PATH
     # if we are inside the Docker container, we avoid downloading the driver
     driver_exe_path = None
     version_main = None
@@ -173,6 +175,8 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
         if PATCHED_DRIVER_PATH is not None:
             driver_exe_path = PATCHED_DRIVER_PATH
 
+    driver_executable_is_patched = PATCHED_DRIVER_IS_PATCHED
+
     # detect chrome path
     browser_executable_path = get_chrome_exe_path()
 
@@ -180,6 +184,7 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     # if we don't set driver_executable_path it downloads, patches, and deletes the driver each time
     driver = uc.Chrome(options=options, browser_executable_path=browser_executable_path,
                        driver_executable_path=driver_exe_path, version_main=version_main,
+                       driver_executable_is_patched=driver_executable_is_patched,
                        windows_headless=windows_headless, headless=windows_headless)
 
     # save the patched driver to avoid re-downloads


### PR DESCRIPTION
- use integer type for CHROME_MAJOR_VERSION to make it work with upstream [undetected-chromedriver](https://github.com/ultrafunkamsterdam/undetected-chromedriver)
- add some config envs, to make this work in a read-only package store (in my case [/nix/store](https://github.com/NixOS/nix))
  - CHROME_EXE_PATH
  - PATCHED_DRIVER_PATH
  - PATCHED_DRIVER_IS_PATCHED

draft PR, because currently, FlareSolverr is using a bundled version of undetected-chromedriver (why?)
in my FlareSolverr package, im using a patched upstream version of undetected-chromedriver

blocked by upstream PRs:

- https://github.com/ultrafunkamsterdam/undetected-chromedriver/pull/1687

tested. works for me

used in

- [nur.repos.milahu.flaresolverr](https://github.com/milahu/nur-packages/blob/master/pkgs/python3/pkgs/flaresolverr/flaresolverr.nix)
- [nur.repos.milahu.undetected-chromedriver](https://github.com/milahu/nur-packages/blob/master/pkgs/development/tools/selenium/chromedriver/undetected-chromedriver.nix)
- [nur.repos.milahu.python3Packages.undetected-chromedriver](https://github.com/milahu/nur-packages/blob/master/pkgs/python3/pkgs/undetected-chromedriver/undetected-chromedriver.nix)



