### PR TITLE
feat: post json support

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,30 @@ Example response from running the `curl` above:
 
 ### + `request.post`
 
-This is the same as `request.get` but it takes one more param:
-
 | Parameter | Notes                                                                    |
 |-----------|--------------------------------------------------------------------------|
-| postData  | Must be a string with `application/x-www-form-urlencoded`. Eg: `a=b&c=d` |
+| contentType  | Supported types: `application/x-www-form-urlencoded`, `application/json`|
+| postData  | Encoded json object or a string with `application/x-www-form-urlencoded`. Eg: `a=b&c=d` |
+
+Example request to post `application/json`:
+```json
+{
+  "cmd": "request.post",
+  "url":"http://example.com",
+  "contentType": "application/json",
+  "postData": "{\"key\":\"myKey\", \"value\": \"epicValue\"}"
+}
+```
+
+Example request to post `application/x-www-form-urlencoded`:
+```json
+{
+  "cmd": "request.post",
+  "url":"http://example.com",
+  "contentType": "application/x-www-form-urlencoded",
+  "postData": "a=b&c=d"
+}
+```
 
 ## Environment variables
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,17 @@
+---
+version: "2.1"
+services:
+  flaresolverr:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: flaresolverr
+    container_name: flaresolverr
+    environment:
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_HTML=${LOG_HTML:-false}
+      - CAPTCHA_SOLVER=${CAPTCHA_SOLVER:-none}
+      - TZ=Europe/London
+    ports:
+      - "${PORT:-8191}:8191"
+    restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ websockets==11.0.3
 xvfbwrapper==0.2.9
 # only required for windows
 pefile==2023.2.7
+selenium_fetch

--- a/src/dtos.py
+++ b/src/dtos.py
@@ -20,6 +20,8 @@ class ChallengeResolutionT:
     message: str = None
     result: ChallengeResolutionResultT = None
 
+    response: str = None
+
     def __init__(self, _dict):
         self.__dict__.update(_dict)
         if self.result is not None:
@@ -39,6 +41,7 @@ class V1RequestBase(object):
 
     # V1Request
     url: str = None
+    contentType: str = None
     postData: str = None
     returnOnlyCookies: bool = None
     download: bool = None   # deprecated v2.0.0, not used

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -3,6 +3,7 @@ import platform
 import sys
 import time
 from datetime import timedelta
+import json
 from urllib.parse import unquote
 
 from func_timeout import FunctionTimedOut, func_timeout
@@ -19,6 +20,7 @@ from dtos import (STATUS_ERROR, STATUS_OK, ChallengeResolutionResultT,
                   ChallengeResolutionT, HealthResponse, IndexResponse,
                   V1RequestBase, V1ResponseBase)
 from sessions import SessionsStorage
+from selenium_fetch import fetch, Options, get_browser_user_agent
 
 ACCESS_DENIED_TITLES = [
     # Cloudflare
@@ -146,6 +148,8 @@ def _cmd_request_get(req: V1RequestBase) -> V1ResponseBase:
         raise Exception("Request parameter 'url' is mandatory in 'request.get' command.")
     if req.postData is not None:
         raise Exception("Cannot use 'postBody' when sending a GET request.")
+    if req.contentType is not None:
+        raise Exception("Cannot use 'contentType' when sending a GET request.")
     if req.returnRawHtml is not None:
         logging.warning("Request parameter 'returnRawHtml' was removed in FlareSolverr v2.")
     if req.download is not None:
@@ -163,6 +167,8 @@ def _cmd_request_post(req: V1RequestBase) -> V1ResponseBase:
     # do some validations
     if req.postData is None:
         raise Exception("Request parameter 'postData' is mandatory in 'request.post' command.")
+    if req.contentType is None:
+        raise Exception("Request parameter 'contentType' is mandatory in 'request.post' command.")
     if req.returnRawHtml is not None:
         logging.warning("Request parameter 'returnRawHtml' was removed in FlareSolverr v2.")
     if req.download is not None:
@@ -295,7 +301,7 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
     # navigate to the page
     logging.debug(f'Navigating to... {req.url}')
     if method == 'POST':
-        _post_request(req, driver)
+        res.response = _post_request(req, driver)
     else:
         driver.get(req.url)
         driver.start_session()  # required to bypass Cloudflare
@@ -308,7 +314,7 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
             driver.add_cookie(cookie)
         # reload the page
         if method == 'POST':
-            _post_request(req, driver)
+            res.response = _post_request(req, driver)
         else:
             driver.get(req.url)
             driver.start_session()  # required to bypass Cloudflare
@@ -395,40 +401,53 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
     challenge_res.userAgent = utils.get_user_agent(driver)
 
     if not req.returnOnlyCookies:
+        content = driver.page_source
+        content = driver.find_element(By.TAG_NAME, "pre").text
+        parsed_json = json.loads(content)
         challenge_res.headers = {}  # todo: fix, selenium not provides this info
-        challenge_res.response = driver.page_source
+        challenge_res.response = res.response if res.response is not None else parsed_json
 
     res.result = challenge_res
     return res
 
 
 def _post_request(req: V1RequestBase, driver: WebDriver):
-    post_form = f'<form id="hackForm" action="{req.url}" method="POST">'
-    query_string = req.postData if req.postData[0] != '?' else req.postData[1:]
-    pairs = query_string.split('&')
-    for pair in pairs:
-        parts = pair.split('=')
-        # noinspection PyBroadException
-        try:
-            name = unquote(parts[0])
-        except Exception:
-            name = parts[0]
-        if name == 'submit':
-            continue
-        # noinspection PyBroadException
-        try:
-            value = unquote(parts[1])
-        except Exception:
-            value = parts[1]
-        post_form += f'<input type="text" name="{name}" value="{value}"><br>'
-    post_form += '</form>'
-    html_content = f"""
-        <!DOCTYPE html>
-        <html>
-        <body>
-            {post_form}
-            <script>document.getElementById('hackForm').submit();</script>
-        </body>
-        </html>"""
-    driver.get("data:text/html;charset=utf-8," + html_content)
-    driver.start_session()  # required to bypass Cloudflare
+    if req.contentType == 'application/x-www-form-urlencoded':
+        post_form = f'<form id="hackForm" action="{req.url}" method="POST">'
+        query_string = req.postData if req.postData[0] != '?' else req.postData[1:]
+        pairs = query_string.split('&')
+        for pair in pairs:
+            parts = pair.split('=')
+            # noinspection PyBroadException
+            try:
+                name = unquote(parts[0])
+            except Exception:
+                name = parts[0]
+            if name == 'submit':
+                continue
+            # noinspection PyBroadException
+            try:
+                value = unquote(parts[1])
+            except Exception:
+                value = parts[1]
+            post_form += f'<input type="text" name="{name}" value="{value}"><br>'
+        post_form += '</form>'
+        html_content = f"""
+            <!DOCTYPE html>
+            <html>
+            <body>
+                {post_form}
+                <script>document.getElementById('hackForm').submit();</script>
+            </body>
+            </html>"""
+        driver.get("data:text/html;charset=utf-8," + html_content)
+        driver.start_session()  # required to bypass Cloudflare
+        return "Success"
+    elif req.contentType == 'application/json':
+        post_data = json.loads(unquote(req.postData))
+        options = Options(method="POST", body=post_data)
+        response = fetch(driver, req.url, options)
+        driver.start_session()  # required to bypass Cloudflare
+        return response.text
+    else:
+        raise Exception(f"Request parameter 'contentType' = '{req.contentType}' is invalid.")


### PR DESCRIPTION
- Added contentType for specifying the content type. Supported types: `application/json`, `application/x-www-form-urlencoded`
- Added `selenium_fetch` package for using fetch with the driver.

### Examples:

Example request to post `application/json`:
```json
{
  "cmd": "request.post",
  "url":"http://example.com",
  "contentType": "application/json",
  "postData": "{\"key\":\"myKey\", \"value\": \"epicValue\"}"
}
```

Example request to post `application/x-www-form-urlencoded`:
```json
{
  "cmd": "request.post",
  "url":"http://example.com",
  "contentType": "application/x-www-form-urlencoded",
  "postData": "a=b&c=d"
}
```