### PR TITLE
Add FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ This is the recommended way for Windows users.
 * Run `pip install -r requirements.txt` command to install FlareSolverr dependencies.
 * Run `python src/flaresolverr.py` command to start FlareSolverr.
 
+### From source code (FreeBSD/TrueNAS CORE)
+
+* Run `pkg install chromium python39 py39-pip xorg-vfbserver` command to install the required dependencies.
+* Clone this repository and open a shell in that path.
+* Run `python3.9 -m pip install -r requirements.txt` command to install FlareSolverr dependencies.
+* Run `python3.9 src/flaresolverr.py` command to start FlareSolverr.
+
 ### Systemd service
 
 We provide an example Systemd unit file `flaresolverr.service` as reference. You have to modify the file to suit your needs: paths, user and environment variables.

--- a/src/undetected_chromedriver/__init__.py
+++ b/src/undetected_chromedriver/__init__.py
@@ -451,8 +451,10 @@ class Chrome(selenium.webdriver.chrome.webdriver.WebDriver):
                 options.binary_location, *options.arguments
             )
         else:
-            startupinfo = subprocess.STARTUPINFO()
+            startupinfo = None
             if os.name == 'nt' and windows_headless:
+                # STARTUPINFO() is Windows only
+                startupinfo = subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             browser = subprocess.Popen(
                 [options.binary_location, *options.arguments],

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import urllib.parse
 import tempfile
+import sys
 
 from selenium.webdriver.chrome.webdriver import WebDriver
 import undetected_chromedriver as uc
@@ -157,7 +158,7 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     # we launch the browser in head-full mode with the window hidden
     windows_headless = False
     if get_config_headless():
-        if os.name == 'nt':
+        if os.name == 'nt' or sys.platform.startswith('freebsd'):
             windows_headless = True
         else:
             start_xvfb_display()
@@ -180,9 +181,12 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
 
     # downloads and patches the chromedriver
     # if we don't set driver_executable_path it downloads, patches, and deletes the driver each time
-    driver = uc.Chrome(options=options, browser_executable_path=browser_executable_path,
-                       driver_executable_path=driver_exe_path, version_main=version_main,
-                       windows_headless=windows_headless, headless=windows_headless)
+    try:
+        driver = uc.Chrome(options=options, browser_executable_path=browser_executable_path,
+                           driver_executable_path=driver_exe_path, version_main=version_main,
+                           windows_headless=windows_headless, headless=windows_headless)
+    except Exception as e:
+        logging.error("Error starting Chrome: %s" % e)
 
     # save the patched driver to avoid re-downloads
     if driver_exe_path is None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -158,7 +158,7 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     # we launch the browser in head-full mode with the window hidden
     windows_headless = False
     if get_config_headless():
-        if os.name == 'nt' or sys.platform.startswith('freebsd'):
+        if os.name == 'nt':
             windows_headless = True
         else:
             start_xvfb_display()


### PR DESCRIPTION
Added support for FreeBSD, since Google doesn't directly provide a binary for FreeBSD, the user needs to have installed the `chromium` package. 
A copy of the chromedriver executable is made in `~/.undetected_chromedriver`, and a `version.txt` file is also created to repatch the executable if an update has been performed.

- Resolves #95
- Closes #919