### PR TITLE
fix captcha solving fixes #1036

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -300,6 +300,7 @@ def get_correct_window(driver: WebDriver) -> WebDriver:
 def access_page(driver: WebDriver, url: str) -> None:
     driver.get(url)
     driver.start_session()
+    driver.start_session()  # required to bypass Cloudflare
 
 
 def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> ChallengeResolutionT:
@@ -311,12 +312,9 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
     # navigate to the page
     logging.debug(f'Navigating to... {req.url}')
     if method == 'POST':
-        access_page(driver, req.url)
         _post_request(req, driver)
     else:
         access_page(driver, req.url)
-        driver.start_session() # required to bypass Cloudflare
-
     driver = get_correct_window(driver)
 
     # set cookies if required
@@ -330,7 +328,6 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
             _post_request(req, driver)
         else:
             access_page(driver, req.url)
-            driver.start_session()  # required to bypass Cloudflare
         driver = get_correct_window(driver)
 
     # wait for the page
@@ -451,4 +448,5 @@ def _post_request(req: V1RequestBase, driver: WebDriver):
         </body>
         </html>"""
     driver.get("data:text/html;charset=utf-8," + html_content)
+    driver.start_session()
     driver.start_session()  # required to bypass Cloudflare

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -297,20 +297,24 @@ def get_correct_window(driver: WebDriver) -> WebDriver:
     return driver
 
 
+def access_page(driver: WebDriver, url: str) -> None:
+    driver.get(url)
+    driver.start_session()
+
+
 def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> ChallengeResolutionT:
     res = ChallengeResolutionT({})
     res.status = STATUS_OK
     res.message = ""
 
+
     # navigate to the page
     logging.debug(f'Navigating to... {req.url}')
-    # Workaround for "challenge not detected" caused by the devtools window
-    driver.get(req.url)
-    driver.start_session() # required to bypass Cloudflare
     if method == 'POST':
+        access_page(driver, req.url)
         _post_request(req, driver)
     else:
-        driver.get(req.url)
+        access_page(driver, req.url)
         driver.start_session() # required to bypass Cloudflare
 
     driver = get_correct_window(driver)

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -329,8 +329,9 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
         if method == 'POST':
             _post_request(req, driver)
         else:
-            driver.get(req.url)
+            access_page(driver, req.url)
             driver.start_session()  # required to bypass Cloudflare
+        driver = get_correct_window(driver)
 
     # wait for the page
     if utils.get_config_log_html():

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -287,6 +287,22 @@ def click_verify(driver: WebDriver):
     time.sleep(2)
 
 
+def get_correct_window(driver: WebDriver) -> WebDriver:
+    if len(driver.window_handles) > 1:
+        for window_handle in driver.window_handles:
+            driver.switch_to.window(window_handle)
+            current_url = driver.current_url
+            if not current_url.startswith("devtools://devtools"):
+                return driver
+    return driver
+
+
+def access_page(driver: WebDriver, url: str) -> None:
+    driver.get(url)
+    driver.start_session()  # required to bypass Cloudflare
+    driver.start_session()
+
+
 def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> ChallengeResolutionT:
     res = ChallengeResolutionT({})
     res.status = STATUS_OK
@@ -294,13 +310,13 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
 
     # navigate to the page
     logging.debug(f'Navigating to... {req.url}')
-    driver.get(req.url)
-    driver.start_session() # required to bypass Cloudflare
     if method == 'POST':
+        access_page(driver, req.url)
         _post_request(req, driver)
     else:
-        driver.get(req.url)
-        driver.start_session()  # required to bypass Cloudflare
+        access_page(driver, req.url)
+
+    driver = get_correct_window(driver)
 
     # set cookies if required
     if req.cookies is not None and len(req.cookies) > 0:

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -297,12 +297,6 @@ def get_correct_window(driver: WebDriver) -> WebDriver:
     return driver
 
 
-def access_page(driver: WebDriver, url: str) -> None:
-    driver.get(url)
-    driver.start_session()  # required to bypass Cloudflare
-    driver.start_session()
-
-
 def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> ChallengeResolutionT:
     res = ChallengeResolutionT({})
     res.status = STATUS_OK
@@ -310,11 +304,14 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
 
     # navigate to the page
     logging.debug(f'Navigating to... {req.url}')
+    # Workaround for "challenge not detected" caused by the devtools window
+    driver.get(req.url)
+    driver.start_session() # required to bypass Cloudflare
     if method == 'POST':
-        access_page(driver, req.url)
         _post_request(req, driver)
     else:
-        access_page(driver, req.url)
+        driver.get(req.url)
+        driver.start_session() # required to bypass Cloudflare
 
     driver = get_correct_window(driver)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -164,6 +164,8 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     # For normal headless mode:
     # options.add_argument('--headless')
 
+    options.add_argument("--auto-open-devtools-for-tabs")
+
     # if we are inside the Docker container, we avoid downloading the driver
     driver_exe_path = None
     version_main = None


### PR DESCRIPTION
Fix for https://github.com/FlareSolverr/FlareSolverr/issues/1036

- starts browser with devtools
- switches to the correct window because it starts with devtools focused and we are interacting with the devtools page instead of the actual page we want
- removing duplicate driver.get, not necessary when doing simple GET requests, only required when doing POST for CORS


![image](https://github.com/FlareSolverr/FlareSolverr/assets/83356979/4010c411-7259-4d8c-a39e-7398faf327f9)

