### PR TITLE
fix(docker): Cleanup deprecated compose config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Supported architectures are:
 | ARM32        | linux/arm/v7 |
 | ARM64        | linux/arm64  |
 
-We provide a `docker-compose.yml` configuration file. Clone this repository and execute `docker-compose up -d` to start
+We provide a `docker-compose.yml` configuration file. Clone this repository and execute
+`docker compose up -d` to start
 the container.
 
 If you prefer the `docker cli` execute the following command.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Supported architectures are:
 | ARM64        | linux/arm64  |
 
 We provide a `docker-compose.yml` configuration file. Clone this repository and execute
-`docker compose up -d` to start
+`docker-compose up -d` _(Compose V1)_ or `docker compose up -d` _(Compose V2)_ to start
 the container.
 
 If you prefer the `docker cli` execute the following command.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "2.1"
 services:
   flaresolverr:
     # DockerHub mirror flaresolverr/flaresolverr:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 ---
+version: "2.1"
 services:
   flaresolverr:
     # DockerHub mirror flaresolverr/flaresolverr:latest


### PR DESCRIPTION
[The `version` key has been deprecated in the docker compose configuration format](https://docs.docker.com/compose/intro/history/#docker-compose-cli-versioning):

    # docker compose ps -a
    WARN[0000] **/docker-compose.yml: `version` is obsolete
    NAME                            IMAGE                                            COMMAND                  SERVICE                         CREATED        STATUS                   PORTS
    ...

Remove it from the example configuration. Also cleanup an out-of-date example of the CLI.