### PR TITLE
Fix pylint warning `raise-missing-from`

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -239,10 +239,10 @@ def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
             driver = utils.get_webdriver(req.proxy)
             logging.debug('New instance of webdriver has been created to perform the request')
         return func_timeout(timeout, _evil_logic, (req, driver, method))
-    except FunctionTimedOut:
-        raise Exception(f'Error solving the challenge. Timeout after {timeout} seconds.')
+    except FunctionTimedOut as exc:
+        raise Exception(f'Error solving the challenge. Timeout after {timeout} seconds.') from exc
     except Exception as e:
-        raise Exception('Error solving the challenge. ' + str(e).replace('\n', '\\n'))
+        raise Exception('Error solving the challenge. ' + str(e).replace('\n', '\\n')) from e
     finally:
         if not req.session and driver is not None:
             if utils.PLATFORM_VERSION == "nt":

--- a/src/utils.py
+++ b/src/utils.py
@@ -319,7 +319,7 @@ def get_user_agent(driver=None) -> str:
         USER_AGENT = re.sub('HEADLESS', '', USER_AGENT, flags=re.IGNORECASE)
         return USER_AGENT
     except Exception as e:
-        raise Exception("Error getting browser User-Agent. " + str(e))
+        raise Exception("Error getting browser User-Agent. " + str(e)) from e
     finally:
         if driver is not None:
             if PLATFORM_VERSION == "nt":


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `raise-missing-from`.
"Python's exception chaining shows the traceback of the current exception, but also of the original exception. When you raise a new exception after another exception was caught it's likely that the second exception is a friendly re-wrapping of the first exception. In such cases `raise from` provides a better link between the two tracebacks in the final error. See [https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.