### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This is the recommended way for Windows users.
 
 ### From source code (FreeBSD/TrueNAS CORE)
 
-* Run `pkg install chromium python39 py39-pip xorg-vfbserver` command to install the required dependencies.
+* Run `pkg install chromium python39 xorg-vfbserver` command to install the required dependencies.
 * Clone this repository and open a shell in that path.
 * Run `python3.9 -m pip install -r requirements.txt` command to install FlareSolverr dependencies.
 * Run `python3.9 src/flaresolverr.py` command to start FlareSolverr.


### PR DESCRIPTION
- py39-pip is not required for FreeBSD, the package does not exist so I've removed it from the install instructions.