### PR TITLE
Access iframe in closed shadow root + click on checkbox from iframe body

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GH_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -53,10 +53,10 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PAT }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -288,11 +288,12 @@ def click_verify(driver: WebDriver):
             return document.querySelector('body');
         """)
         if iframe_body:
+            iframe_body.click()
             actions = ActionChains(driver)
             actions.move_to_element_with_offset(iframe_body, 10, 10)
             actions.click(iframe_body)
             actions.perform()
-            logging.debug("Cloudflare verify checkbox found and clicked!")
+            logging.debug("Attempted to click on iframe body")
     except Exception as e:
         logging.debug("Cloudflare verify checkbox not found on the page. %s", repr(e))
     finally:

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -282,11 +282,9 @@ def get_shadowed_iframe(driver: WebDriver, css_selector: str):
 def click_verify(driver: WebDriver):
     try:
         logging.debug("Try to find the Cloudflare verify checkbox...")
-        iframe = get_shadowed_iframe(driver, "div.cf-turnstile-wrapper")
+        iframe = get_shadowed_iframe(driver, "div:not(:has(div))")
         driver.switch_to.frame(iframe)
-        iframe_body = driver.execute_script("""
-            return document.querySelector('body');
-        """)
+        iframe_body = driver.find_element(By.CSS_SELECTOR, "body")
         if iframe_body:
             iframe_body.click()
             actions = ActionChains(driver)

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -219,6 +219,20 @@ def _cmd_sessions_destroy(req: V1RequestBase) -> V1ResponseBase:
         "message": "The session has been removed."
     })
 
+def _init_driver(driver):
+    try:
+        driver.execute_cdp_cmd('Page.enable', {})
+        driver.execute_cdp_cmd('Page.addScriptToEvaluateOnNewDocument', {
+            'source': """
+                Element.prototype._as = Element.prototype.attachShadow;
+                Element.prototype.attachShadow = function (params) {
+                    return this._as({mode: "open"})
+                };
+            """
+        })
+    except Exception as e:
+        logging.debug("Driver init exception: %s", repr(e))
+
 
 def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
     timeout = int(req.maxTimeout) / 1000
@@ -239,6 +253,7 @@ def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
         else:
             driver = utils.get_webdriver(req.proxy)
             logging.debug('New instance of webdriver has been created to perform the request')
+        _init_driver(driver)
         return func_timeout(timeout, _evil_logic, (req, driver, method))
     except FunctionTimedOut:
         raise Exception(f'Error solving the challenge. Timeout after {timeout} seconds.')
@@ -252,23 +267,34 @@ def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
             logging.debug('A used instance of webdriver has been destroyed')
 
 
+def get_shadowed_iframe(driver: WebDriver, css_selector: str):
+    logging.debug("Getting ShadowRoot by selector: %s", css_selector)
+    shadow_element = driver.execute_script("""
+        return document.querySelector(arguments[0]).shadowRoot.firstChild;
+    """, css_selector)
+    if shadow_element:
+        logging.debug("iframe found")
+    else:
+        logging.debug("iframe not found")
+    return shadow_element
+
+
 def click_verify(driver: WebDriver):
     try:
         logging.debug("Try to find the Cloudflare verify checkbox...")
-        iframe = driver.find_element(By.XPATH, "//iframe[starts-with(@id, 'cf-chl-widget-')]")
+        iframe = get_shadowed_iframe(driver, "div.cf-turnstile-wrapper")
         driver.switch_to.frame(iframe)
-        checkbox = driver.find_element(
-            by=By.XPATH,
-            value='//*[@id="content"]/div/div/label/input',
-        )
-        if checkbox:
+        iframe_body = driver.execute_script("""
+            return document.querySelector('body');
+        """)
+        if iframe_body:
             actions = ActionChains(driver)
-            actions.move_to_element_with_offset(checkbox, 5, 7)
-            actions.click(checkbox)
+            actions.move_to_element_with_offset(iframe_body, 10, 10)
+            actions.click(iframe_body)
             actions.perform()
             logging.debug("Cloudflare verify checkbox found and clicked!")
-    except Exception:
-        logging.debug("Cloudflare verify checkbox not found on the page.")
+    except Exception as e:
+        logging.debug("Cloudflare verify checkbox not found on the page. %s", repr(e))
     finally:
         driver.switch_to.default_content()
 


### PR DESCRIPTION
Hi ! Here is something fixing issue #1253
At least it works for me since yesterday :slightly_smiling_face:

Here is the problem as I understood it:
```
Page DOM
├─ Closed shadow root
   ├─ Iframe
      ├─ Closed shadow root
         ├─ Checkbox
```
The checkbox is in a closed shadow root, inside an iframe, inside a closed shadow root. And you can’t get elements in a closed shadow-root.

Most of the work comes from @alexandervlk, [here](https://github.com/FlareSolverr/FlareSolverr/issues/1253#issuecomment-2223149319) 
He made the `_init_driver` function: it inject a script before page loading that make the first shadow-root open.
This is allowing to run a js script to get the Iframe in the first shadow-root (`get_shadowed_iframe` function) , and then switch the driver to the Iframe

Then, there is the last closed shadow-root. I was not able to find how to make it open. The `_init_driver`  does not inject in the iFrame, and I can’t find how to do it. So I am not able to get the checkbox for now.
But I found a workaround by selecting the iframe body (which is just before this last closed shadow-root in DOM tree) and then manage to click on the checkbox from the body.

I never coded in python before, nor I made a pull request on a public github, so be kind :pray: