### PR TITLE
Feature: Screenshot parameter to screenshot the web page

### DIFF
--- a/src/dtos.py
+++ b/src/dtos.py
@@ -10,6 +10,7 @@ class ChallengeResolutionResultT:
     response: str = None
     cookies: list = None
     userAgent: str = None
+    screenshot: str | None = None
 
     def __init__(self, _dict):
         self.__dict__.update(_dict)
@@ -41,6 +42,7 @@ class V1RequestBase(object):
     url: str = None
     postData: str = None
     returnOnlyCookies: bool = None
+    returnScreenshot: bool = None
     download: bool = None   # deprecated v2.0.0, not used
     returnRawHtml: bool = None  # deprecated v2.0.0, not used
 

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -418,6 +418,9 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
         challenge_res.headers = {}  # todo: fix, selenium not provides this info
         challenge_res.response = driver.page_source
 
+    if req.returnScreenshot:
+        challenge_res.screenshot = driver.get_screenshot_as_base64()
+
     res.result = challenge_res
     return res
 


### PR DESCRIPTION
As the title says, adds a screenshot parameter to screenshot the web page and returns image data as base64.

For context, I'm scraping a website hosting images protected by cloudflare and for my use case it's easier to just add this parameter than having to deal with cookies (I don't care about resolution of the images and cropping is done in one line). Maybe it's not relevant for my use case since one can just achieve the same result with cookies, but it may be relevant to others since sometimes you may need a screenshot of the whole web page.