### PR TITLE
Add Log File support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,12 @@ RUN dpkg -i /libgl1-mesa-dri.deb \
     # Create flaresolverr user
     && useradd --home-dir /app --shell /bin/sh flaresolverr \
     && mv /usr/bin/chromedriver chromedriver \
-    && chown -R flaresolverr:flaresolverr .
+    && chown -R flaresolverr:flaresolverr . \
+    # Create config dir
+    && mkdir /config \
+    && chown flaresolverr:flaresolverr /config
+
+VOLUME /config
 
 # Install Python dependencies
 COPY requirements.txt .

--- a/README.md
+++ b/README.md
@@ -264,10 +264,11 @@ This is the same as `request.get` but it takes one more param:
 | Name               | Default                | Notes                                                                                                                                                         |
 |--------------------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | LOG_LEVEL          | info                   | Verbosity of the logging. Use `LOG_LEVEL=debug` for more information.                                                                                         |
+| LOG_FILE           | none                   | Capture log to file.                                                                                                                                          |
 | LOG_HTML           | false                  | Only for debugging. If `true` all HTML that passes through the proxy will be logged to the console in `debug` level.                                          |
 | CAPTCHA_SOLVER     | none                   | Captcha solving method. It is used when a captcha is encountered. See the Captcha Solvers section.                                                            |
 | TZ                 | UTC                    | Timezone used in the logs and the web browser. Example: `TZ=Europe/London`.                                                                                   |
-| LANG               | none                   | Language used in the web browser. Example: `LANG=en_GB`.                                                                                   |
+| LANG               | none                   | Language used in the web browser. Example: `LANG=en_GB`.                                                                                                      |
 | HEADLESS           | true                   | Only for debugging. To run the web browser in headless mode or visible.                                                                                       |
 | BROWSER_TIMEOUT    | 40000                  | If you are experiencing errors/timeouts because your system is slow, you can try to increase this value. Remember to increase the `maxTimeout` parameter too. |
 | TEST_URL           | https://www.google.com | FlareSolverr makes a request on start to make sure the web browser is working. You can change that URL if it is blocked in your country.                      |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,12 @@ services:
     container_name: flaresolverr
     environment:
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_FILE=flaresolver.log
       - LOG_HTML=${LOG_HTML:-false}
       - CAPTCHA_SOLVER=${CAPTCHA_SOLVER:-none}
       - TZ=Europe/London
     ports:
       - "${PORT:-8191}:8191"
+    volumes:
+      - /var/lib/flaresolver:/config
     restart: unless-stopped

--- a/src/flaresolverr.py
+++ b/src/flaresolverr.py
@@ -76,6 +76,7 @@ if __name__ == "__main__":
 
     # validate configuration
     log_level = os.environ.get('LOG_LEVEL', 'info').upper()
+    log_file = os.environ.get('LOG_FILE', None)
     log_html = utils.get_config_log_html()
     headless = utils.get_config_headless()
     server_host = os.environ.get('HOST', '0.0.0.0')
@@ -93,6 +94,15 @@ if __name__ == "__main__":
             logging.StreamHandler(sys.stdout)
         ]
     )
+    if log_file:
+        if not log_file.startswith("/config"):
+            log_file = "/config/" + log_file
+        log_file = os.path.realpath(log_file)
+        log_path = os.path.dirname(log_file)
+        os.makedirs(log_path, exist_ok=True)
+
+        logging.getLogger().addHandler(logging.FileHandler(log_file))
+
     # disable warning traces from urllib3
     logging.getLogger('urllib3').setLevel(logging.ERROR)
     logging.getLogger('selenium.webdriver.remote.remote_connection').setLevel(logging.WARNING)


### PR DESCRIPTION
when debugging various issues having a log file generated is much easier to work through than using `stdout`. 
As for path choose `/config` as that seems to be the convention with much of the dockers I work with.