### PR TITLE
fix(request): handle empty string in postData on /v1 endpoint (#1548)

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -398,7 +398,7 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
 
 def _post_request(req: V1RequestBase, driver: WebDriver):
     post_form = f'<form id="hackForm" action="{req.url}" method="POST">'
-    query_string = req.postData if req.postData[0] != '?' else req.postData[1:]
+    query_string = req.postData if req.postData and req.postData[0] != '?' else req.postData[1:] if req.postData else ''
     pairs = query_string.split('&')
     for pair in pairs:
         parts = pair.split('=')


### PR DESCRIPTION
Fixes #1548

Summary:
The `request.post` method was failing on the /v1 endpoint when `postData` was an empty string.  
This PR changes the handling of `postData` to properly account for the empty string case.

Before :
```py
query_string = req.postData if req.postData[0] != '?' else req.postData[1:]
```

After :
```py
query_string = req.postData if req.postData and req.postData[0] != '?' else req.postData[1:] if req.postData else ''
```