### PR TITLE
fix: handle empty string and keys without value in postData on /v1 endpoint (#1548)

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -401,7 +401,7 @@ def _post_request(req: V1RequestBase, driver: WebDriver):
     query_string = req.postData if req.postData and req.postData[0] != '?' else req.postData[1:] if req.postData else ''
     pairs = query_string.split('&')
     for pair in pairs:
-        parts = pair.split('=')
+        parts = pair.split('=', 1)
         # noinspection PyBroadException
         try:
             name = unquote(parts[0])
@@ -411,9 +411,9 @@ def _post_request(req: V1RequestBase, driver: WebDriver):
             continue
         # noinspection PyBroadException
         try:
-            value = unquote(parts[1])
+            value = unquote(parts[1]) if len(parts) > 1 else ''
         except Exception:
-            value = parts[1]
+            value = parts[1] if len(parts) > 1 else ''
         post_form += f'<input type="text" name="{escape(quote(name))}" value="{escape(quote(value))}"><br>'
     post_form += '</form>'
     html_content = f"""

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -398,7 +398,7 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
 
 def _post_request(req: V1RequestBase, driver: WebDriver):
     post_form = f'<form id="hackForm" action="{req.url}" method="POST">'
-    query_string = req.postData if req.postData[0] != '?' else req.postData[1:]
+    query_string = req.postData if req.postData and req.postData[0] != '?' else req.postData[1:] if req.postData else ''
     pairs = query_string.split('&')
     for pair in pairs:
         parts = pair.split('=')


### PR DESCRIPTION
Fixes #1548

Summary:
The request.post method was failing on the /v1 endpoint when postData was an empty string.
Additionally, it fixes an IndexError occurring when a key without an associated value is provided in postData.
This PR changes the handling of postData to properly account for the empty-string case and keys without values.

Before :
```py
query_string = req.postData if req.postData[0] != '?' else req.postData[1:]
pairs = query_string.split('&')
for pair in pairs:
    parts = pair.split('=')
    # noinspection PyBroadException
    try:
        name = unquote(parts[0])
    except Exception:
        name = parts[0]
    if name == 'submit':
        continue
    # noinspection PyBroadException
    try:
        value = unquote(parts[1])
    except Exception:
        value = parts[1]
```

After :
```py
query_string = req.postData if req.postData and req.postData[0] != '?' else req.postData[1:] if req.postData else ''
pairs = query_string.split('&')
for pair in pairs:
    parts = pair.split('=', 1)
    # noinspection PyBroadException
    try:
        name = unquote(parts[0])
    except Exception:
        name = parts[0]
    if name == 'submit':
        continue
    # noinspection PyBroadException
    try:
        value = unquote(parts[1]) if len(parts) > 1 else ''
    except Exception:
        value = parts[1] if len(parts) > 1 else ''
```