### PR TITLE
Add network interceptor for capturing Ahrefs API responses

### DIFF
--- a/AHREFS_CAPTURE_README.md
+++ b/AHREFS_CAPTURE_README.md
@@ -1,0 +1,236 @@
+# Ahrefs API Response Capture Feature
+
+This feature automatically captures and saves API responses when using FlareSolverr to access Ahrefs traffic checker.
+
+## How It Works
+
+1. **Automatic Detection**: When FlareSolverr detects an Ahrefs URL, it automatically enables network interception
+2. **Captcha Solving**: FlareSolverr solves any Cloudflare captchas as usual
+3. **API Interception**: The page automatically calls `https://ahrefs.com/v4/stGetFreeTrafficOverview` after captcha is solved
+4. **Response Capture**: The network interceptor captures this API response
+5. **File Saving**: Responses are saved to `captured_responses/` directory in both `.txt` and `.json` formats
+
+## Usage
+
+### Method 1: Using the Example Script
+
+```bash
+# Make sure FlareSolverr is running
+python example_ahrefs_capture.py
+```
+
+### Method 2: Using curl
+
+```bash
+curl -X POST http://localhost:8191/v1 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "cmd": "request.get",
+    "url": "https://ahrefs.com/traffic-checker/?input=yep.com&mode=subdomains",
+    "maxTimeout": 60000
+  }'
+```
+
+### Method 3: Using Python requests
+
+```python
+import requests
+
+response = requests.post('http://localhost:8191/v1', json={
+    "cmd": "request.get",
+    "url": "https://ahrefs.com/traffic-checker/?input=example.com&mode=subdomains",
+    "maxTimeout": 60000
+})
+
+print(response.json())
+```
+
+## Output Files
+
+The captured responses are saved in the `captured_responses/` directory with the following naming pattern:
+
+```
+captured_responses/
+├── 20250116_143052_123456_ahrefs.com_v4_stGetFreeTrafficOverview.txt
+└── 20250116_143052_123456_ahrefs.com_v4_stGetFreeTrafficOverview.json
+```
+
+### Text File Format (.txt)
+
+The `.txt` file contains:
+- Request metadata (URL, method, timestamp, status)
+- Full response body in plain text
+
+Example:
+```
+================================================================================
+CAPTURED API RESPONSE
+================================================================================
+
+URL: https://ahrefs.com/v4/stGetFreeTrafficOverview
+Method: GET
+Timestamp: 2025-01-16T14:30:52.123456
+Status: 200
+
+================================================================================
+RESPONSE BODY
+================================================================================
+
+{"domain": "yep.com", "traffic": {...}, ...}
+
+================================================================================
+```
+
+### JSON File Format (.json)
+
+The `.json` file contains:
+- `metadata`: Request information
+- `body`: Parsed JSON response
+
+Example:
+```json
+{
+  "metadata": {
+    "url": "https://ahrefs.com/v4/stGetFreeTrafficOverview",
+    "method": "GET",
+    "timestamp": "2025-01-16T14:30:52.123456",
+    "response_status": 200
+  },
+  "body": {
+    "domain": "yep.com",
+    "traffic": {...}
+  }
+}
+```
+
+## Configuration
+
+The interceptor is configured in `src/network_interceptor.py` and monitors these URLs by default:
+
+- `ahrefs.com/v4/stGetFreeTrafficOverview`
+- `ahrefs.com/api/*` (any other API calls)
+
+### Customizing Target URLs
+
+To capture different API endpoints, edit `create_ahrefs_interceptor()` in `src/network_interceptor.py`:
+
+```python
+def create_ahrefs_interceptor(driver: Chrome, output_dir: str = "captured_responses") -> NetworkInterceptor:
+    target_urls = [
+        'ahrefs.com/v4/stGetFreeTrafficOverview',
+        'ahrefs.com/v4/yourNewEndpoint',  # Add your endpoints here
+    ]
+
+    interceptor = NetworkInterceptor(driver, target_urls, output_dir)
+    return interceptor
+```
+
+### Changing Output Directory
+
+By default, responses are saved to `captured_responses/`. To change this, modify the `output_dir` parameter when creating the interceptor in `src/flaresolverr_service.py`:
+
+```python
+interceptor = create_ahrefs_interceptor(driver, output_dir="your_custom_directory")
+```
+
+## Logging
+
+The interceptor provides detailed logging:
+
+```
+[INFO] Ahrefs URL detected - enabling network interceptor
+[INFO] Network interceptor enabled for URLs: ['ahrefs.com/v4/stGetFreeTrafficOverview', ...]
+[INFO] Intercepted request: https://ahrefs.com/v4/stGetFreeTrafficOverview
+[INFO] Intercepted response: https://ahrefs.com/v4/stGetFreeTrafficOverview
+[INFO] Response saved to: captured_responses/20250116_143052_123456_ahrefs.com_v4_stGetFreeTrafficOverview.txt
+[INFO] JSON response saved to: captured_responses/20250116_143052_123456_ahrefs.com_v4_stGetFreeTrafficOverview.json
+[INFO] Successfully captured 1 API response(s):
+[INFO]   - captured_responses/20250116_143052_123456_ahrefs.com_v4_stGetFreeTrafficOverview.txt
+```
+
+## How to Run FlareSolverr
+
+### Using Docker (Recommended)
+
+```bash
+docker run -d \
+  --name flaresolverr \
+  -p 8191:8191 \
+  -v $(pwd)/captured_responses:/app/captured_responses \
+  ghcr.io/flaresolverr/flaresolverr:latest
+```
+
+### Running Locally
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run FlareSolverr
+python src/flaresolverr.py
+```
+
+## Troubleshooting
+
+### No responses captured
+
+If you see "No API responses were captured", try:
+
+1. **Increase wait time**: The default wait is 5 seconds. You can increase this in `src/flaresolverr_service.py`:
+   ```python
+   time.sleep(10)  # Wait 10 seconds instead of 5
+   ```
+
+2. **Check if API is called**: Manually visit the Ahrefs URL in your browser and check the Network tab to verify the API is called after captcha
+
+3. **Enable debug logging**: Check FlareSolverr logs for any errors during interception
+
+### Permission errors
+
+If you get permission errors when saving files:
+
+```bash
+# Make sure the output directory is writable
+mkdir -p captured_responses
+chmod 777 captured_responses
+```
+
+## Technical Details
+
+### Architecture
+
+The interceptor uses Chrome DevTools Protocol (CDP) to monitor network traffic:
+
+1. `Network.enable` - Enables network tracking
+2. `Network.requestWillBeSent` - Captures outgoing requests
+3. `Network.responseReceived` - Captures response headers
+4. `Network.loadingFinished` - Retrieves response body via `Network.getResponseBody`
+
+### File Structure
+
+```
+src/
+├── network_interceptor.py      # Network interception module
+├── flaresolverr_service.py     # Integration point
+└── ...
+
+captured_responses/             # Output directory (created automatically)
+├── *.txt                       # Text format responses
+└── *.json                      # JSON format responses
+
+example_ahrefs_capture.py       # Example usage script
+```
+
+## Educational Purpose & Authorization
+
+This feature is designed for:
+- Educational purposes
+- Authorized testing of your own Ahrefs traffic
+- Debugging and development
+- Research with proper authorization
+
+**Important**: Only use this feature with your own authorized Ahrefs account and traffic. Do not use it to scrape or abuse Ahrefs services.
+
+## License
+
+Same license as FlareSolverr (MIT).

--- a/example_ahrefs_capture.py
+++ b/example_ahrefs_capture.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Example script to use FlareSolverr with Ahrefs traffic checker
+and capture API responses automatically.
+
+This demonstrates how to:
+1. Send a request to FlareSolverr
+2. Let it solve the captcha on Ahrefs
+3. Automatically capture the API response that the page makes
+4. Save it to a text file
+"""
+
+import requests
+import json
+import time
+
+# FlareSolverr endpoint (default: http://localhost:8191)
+FLARESOLVERR_URL = "http://localhost:8191/v1"
+
+# Target Ahrefs URL
+AHREFS_URL = "https://ahrefs.com/traffic-checker/?input=yep.com&mode=subdomains"
+
+
+def capture_ahrefs_traffic(domain: str = "yep.com", mode: str = "subdomains"):
+    """
+    Capture Ahrefs traffic data by solving captcha and intercepting API calls
+
+    Args:
+        domain: Domain to check traffic for
+        mode: Mode (subdomains, prefix, exact)
+
+    Returns:
+        Response from FlareSolverr
+    """
+    url = f"https://ahrefs.com/traffic-checker/?input={domain}&mode={mode}"
+
+    # Prepare the request to FlareSolverr
+    payload = {
+        "cmd": "request.get",
+        "url": url,
+        "maxTimeout": 60000,  # 60 seconds timeout
+        "returnOnlyCookies": False
+    }
+
+    print(f"[*] Sending request to FlareSolverr...")
+    print(f"[*] Target URL: {url}")
+    print(f"[*] FlareSolverr will solve any captchas and capture API responses...")
+
+    try:
+        response = requests.post(FLARESOLVERR_URL, json=payload)
+        response.raise_for_status()
+
+        result = response.json()
+
+        if result.get("status") == "ok":
+            print(f"\n[✓] Success!")
+            print(f"[✓] Challenge status: {result.get('message')}")
+            print(f"\n[*] API responses have been saved to 'captured_responses/' directory")
+            print(f"[*] Check the logs above for the exact file paths")
+
+            return result
+        else:
+            print(f"\n[✗] Error: {result.get('message')}")
+            return None
+
+    except requests.exceptions.RequestException as e:
+        print(f"\n[✗] Request failed: {e}")
+        return None
+
+
+def main():
+    print("=" * 80)
+    print("Ahrefs Traffic Capture Example")
+    print("=" * 80)
+    print()
+
+    # Example 1: Check traffic for yep.com with subdomains
+    print("Example 1: Checking traffic for yep.com (subdomains mode)")
+    print("-" * 80)
+    capture_ahrefs_traffic("yep.com", "subdomains")
+
+    print("\n" + "=" * 80)
+    print("Done! Check the 'captured_responses/' directory for saved API responses.")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/network_interceptor.py
+++ b/src/network_interceptor.py
@@ -1,0 +1,258 @@
+"""
+Network Interceptor Module
+Captures and saves responses from specific API endpoints
+"""
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Optional
+from selenium.webdriver import Chrome
+
+log = logging.getLogger('flaresolverr')
+
+
+class NetworkInterceptor:
+    """
+    Intercepts network requests and responses using Chrome DevTools Protocol (CDP)
+    """
+
+    def __init__(self, driver: Chrome, target_urls: list[str], output_dir: str = "captured_responses"):
+        """
+        Initialize the network interceptor
+
+        Args:
+            driver: Selenium Chrome WebDriver instance
+            target_urls: List of URL patterns to intercept (supports partial matching)
+            output_dir: Directory to save captured responses
+        """
+        self.driver = driver
+        self.target_urls = target_urls
+        self.output_dir = output_dir
+        self.captured_responses = []
+
+        # Create output directory if it doesn't exist
+        os.makedirs(output_dir, exist_ok=True)
+
+        # Storage for request-response mapping
+        self.requests = {}
+
+    def enable(self):
+        """
+        Enable network interception by registering CDP event listeners
+        """
+        try:
+            # Enable network tracking
+            self.driver.execute_cdp_cmd('Network.enable', {})
+
+            # Add CDP event listeners
+            self.driver.add_cdp_listener('Network.requestWillBeSent', self._on_request_sent)
+            self.driver.add_cdp_listener('Network.responseReceived', self._on_response_received)
+            self.driver.add_cdp_listener('Network.loadingFinished', self._on_loading_finished)
+
+            log.info(f"Network interceptor enabled for URLs: {self.target_urls}")
+            return True
+
+        except Exception as e:
+            log.error(f"Failed to enable network interceptor: {e}")
+            return False
+
+    def _matches_target_url(self, url: str) -> bool:
+        """
+        Check if URL matches any of the target URLs
+
+        Args:
+            url: URL to check
+
+        Returns:
+            True if URL matches any target pattern
+        """
+        return any(target in url for target in self.target_urls)
+
+    def _on_request_sent(self, message: dict):
+        """
+        Handler for Network.requestWillBeSent event
+
+        Args:
+            message: CDP event message
+        """
+        try:
+            params = message.get('params', {})
+            request_id = params.get('requestId')
+            request = params.get('request', {})
+            url = request.get('url', '')
+
+            if self._matches_target_url(url):
+                log.info(f"Intercepted request: {url}")
+                self.requests[request_id] = {
+                    'url': url,
+                    'method': request.get('method'),
+                    'headers': request.get('headers'),
+                    'timestamp': datetime.now().isoformat()
+                }
+        except Exception as e:
+            log.error(f"Error in _on_request_sent: {e}")
+
+    def _on_response_received(self, message: dict):
+        """
+        Handler for Network.responseReceived event
+
+        Args:
+            message: CDP event message
+        """
+        try:
+            params = message.get('params', {})
+            request_id = params.get('requestId')
+            response = params.get('response', {})
+            url = response.get('url', '')
+
+            if self._matches_target_url(url) and request_id in self.requests:
+                log.info(f"Intercepted response: {url}")
+                self.requests[request_id]['response'] = {
+                    'status': response.get('status'),
+                    'statusText': response.get('statusText'),
+                    'headers': response.get('headers'),
+                    'mimeType': response.get('mimeType')
+                }
+        except Exception as e:
+            log.error(f"Error in _on_response_received: {e}")
+
+    def _on_loading_finished(self, message: dict):
+        """
+        Handler for Network.loadingFinished event
+        Retrieves and saves the response body
+
+        Args:
+            message: CDP event message
+        """
+        try:
+            params = message.get('params', {})
+            request_id = params.get('requestId')
+
+            if request_id in self.requests:
+                request_data = self.requests[request_id]
+                url = request_data['url']
+
+                # Get response body using CDP
+                try:
+                    response = self.driver.execute_cdp_cmd('Network.getResponseBody', {
+                        'requestId': request_id
+                    })
+
+                    body = response.get('body', '')
+                    base64_encoded = response.get('base64Encoded', False)
+
+                    if base64_encoded:
+                        import base64
+                        body = base64.b64decode(body).decode('utf-8')
+
+                    # Save the response
+                    self._save_response(request_data, body)
+
+                    # Clean up
+                    del self.requests[request_id]
+
+                except Exception as e:
+                    log.warning(f"Could not get response body for {url}: {e}")
+
+        except Exception as e:
+            log.error(f"Error in _on_loading_finished: {e}")
+
+    def _save_response(self, request_data: dict, body: str):
+        """
+        Save captured response to a file
+
+        Args:
+            request_data: Request metadata
+            body: Response body
+        """
+        try:
+            url = request_data['url']
+            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S_%f')
+
+            # Create filename from URL and timestamp
+            url_safe = url.replace('https://', '').replace('http://', '').replace('/', '_').replace('?', '_')[:100]
+            filename = f"{timestamp}_{url_safe}.txt"
+            filepath = os.path.join(self.output_dir, filename)
+
+            # Prepare metadata
+            metadata = {
+                'url': url,
+                'method': request_data.get('method'),
+                'timestamp': request_data.get('timestamp'),
+                'response_status': request_data.get('response', {}).get('status'),
+                'response_headers': request_data.get('response', {}).get('headers'),
+            }
+
+            # Save to file
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.write("=" * 80 + "\n")
+                f.write("CAPTURED API RESPONSE\n")
+                f.write("=" * 80 + "\n\n")
+                f.write(f"URL: {metadata['url']}\n")
+                f.write(f"Method: {metadata['method']}\n")
+                f.write(f"Timestamp: {metadata['timestamp']}\n")
+                f.write(f"Status: {metadata['response_status']}\n")
+                f.write("\n" + "=" * 80 + "\n")
+                f.write("RESPONSE BODY\n")
+                f.write("=" * 80 + "\n\n")
+                f.write(body)
+                f.write("\n\n" + "=" * 80 + "\n")
+
+            log.info(f"Response saved to: {filepath}")
+            self.captured_responses.append(filepath)
+
+            # Also save as JSON if the body is JSON
+            try:
+                json_data = json.loads(body)
+                json_filepath = filepath.replace('.txt', '.json')
+                with open(json_filepath, 'w', encoding='utf-8') as f:
+                    json.dump({
+                        'metadata': metadata,
+                        'body': json_data
+                    }, f, indent=2, ensure_ascii=False)
+                log.info(f"JSON response saved to: {json_filepath}")
+            except:
+                pass  # Not JSON, that's fine
+
+        except Exception as e:
+            log.error(f"Error saving response: {e}")
+
+    def get_captured_responses(self) -> list[str]:
+        """
+        Get list of captured response file paths
+
+        Returns:
+            List of file paths
+        """
+        return self.captured_responses
+
+    def disable(self):
+        """
+        Disable network interception
+        """
+        try:
+            self.driver.execute_cdp_cmd('Network.disable', {})
+            log.info("Network interceptor disabled")
+        except Exception as e:
+            log.error(f"Error disabling network interceptor: {e}")
+
+
+def create_ahrefs_interceptor(driver: Chrome, output_dir: str = "captured_responses") -> NetworkInterceptor:
+    """
+    Create a network interceptor specifically for Ahrefs traffic checker API
+
+    Args:
+        driver: Selenium Chrome WebDriver instance
+        output_dir: Directory to save captured responses
+
+    Returns:
+        Configured NetworkInterceptor instance
+    """
+    target_urls = [
+        'ahrefs.com/v4/stGetFreeTrafficOverview',
+        'ahrefs.com/api/',  # Catch other potential API calls
+    ]
+
+    interceptor = NetworkInterceptor(driver, target_urls, output_dir)
+    return interceptor


### PR DESCRIPTION
This feature automatically captures and saves API responses when accessing Ahrefs URLs through FlareSolverr. When an Ahrefs URL is detected, the interceptor uses Chrome DevTools Protocol to monitor network traffic and save responses from stGetFreeTrafficOverview and other Ahrefs API endpoints to text and JSON files.

Changes:
- Add network_interceptor.py module with CDP-based request interception
- Integrate interceptor into flaresolverr_service.py for Ahrefs URLs
- Add example_ahrefs_capture.py demonstrating usage
- Add AHREFS_CAPTURE_README.md with comprehensive documentation

Responses are automatically saved to captured_responses/ directory in both .txt and .json formats for easy analysis and debugging.