### PR TITLE
[RFC] Add browser fetch() for image downloads to bypass TLS fingerprinting

### DIFF
--- a/src/dtos.py
+++ b/src/dtos.py
@@ -10,7 +10,6 @@ class ChallengeResolutionResultT:
     response: str = None
     cookies: list = None
     userAgent: str = None
-    screenshot: str | None = None
 
     def __init__(self, _dict):
         self.__dict__.update(_dict)
@@ -42,10 +41,9 @@ class V1RequestBase(object):
     url: str = None
     postData: str = None
     returnOnlyCookies: bool = None
-    returnScreenshot: bool = None
     download: bool = None   # deprecated v2.0.0, not used
+    downloadUrls: list = None  # Optional: specific image URLs to download
     returnRawHtml: bool = None  # deprecated v2.0.0, not used
-    waitInSeconds: int = None
 
     def __init__(self, _dict):
         self.__dict__.update(_dict)


### PR DESCRIPTION
## Problem

Some websites (like Priority Tire) use TLS fingerprinting (JA3/JA4) to block non-browser HTTP clients. Python's `requests.get()` gets blocked, preventing image downloads.

## Solution

Replace Python HTTP requests with browser-side JavaScript `fetch()` API for image downloads. The browser's native fetch has the same TLS fingerprint as regular browsing, bypassing detection.

## Changes

- **src/flaresolverr_service.py**: Use `driver.execute_script()` with `fetch()` to download images
- **src/dtos.py**: Add `downloadUrls` parameter for selective image downloading

## Use Case

This enables scraping sites with aggressive bot detection that specifically target Python HTTP libraries.

---
**Note**: This PR is for discussion/visualization purposes. Happy to refine based on feedback.