### PR TITLE
Added healthcheck to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,8 @@ services:
     volumes:
       - /var/lib/flaresolver:/config
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8191/health | grep -q '\"status\": \"ok'"]
+      interval: 30s
+      timeout: 10s
+      retries: 3


### PR DESCRIPTION
By checking the builtin health endpoint, we can be sure the container restarts if it becomes unhealthy.