### PR TITLE
fixed multiple buttons bug for tabs_till_verify

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -305,10 +305,16 @@ def _get_turnstile_token(driver: WebDriver, tabs: int):
 
         # reset focus
         driver.execute_script("""
+            let old = document.getElementById('__focus_helper');
+            if (old) old.remove();
+
             let el = document.createElement('button');
-            el.style.position='fixed';
-            el.style.top='0';
-            el.style.left='0';
+            el.id = '__focus_helper';
+            el.style.position = 'fixed';
+            el.style.top = '0';
+            el.style.left = '0';
+            el.style.opacity = '0.01';
+            el.style.pointerEvents = 'none';
             document.body.prepend(el);
             el.focus();
         """)


### PR DESCRIPTION
In previous code when reseting the focus in the turnstile captcha It would create button at the 0.0 to then go there but the problem is when captcha wasnt solved the first time it would then create multiple buttons at the top 0.0 and it would never get to the captcha ever since the tabs_till_verify is fixed, now i delete the button each time before creating new one to avoid this bug

in order to test this take any turnstile captcha website and put tabs_till_verify not to the captcha its self in order to see it with your eyes where it would get you each time it resets

Fixes #1678