### PR TITLE
Fix cookies being retrieved before waitInSeconds delay

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -466,7 +466,6 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
     challenge_res = ChallengeResolutionResultT({})
     challenge_res.url = driver.current_url
     challenge_res.status = 200  # todo: fix, selenium not provides this info
-    challenge_res.cookies = driver.get_cookies()
     challenge_res.userAgent = utils.get_user_agent(driver)
     challenge_res.turnstile_token = turnstile_token
 
@@ -481,6 +480,9 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
 
     if req.returnScreenshot:
         challenge_res.screenshot = driver.get_screenshot_as_base64()
+
+    # Get cookies after all waits to capture cookies set during JavaScript execution
+    challenge_res.cookies = driver.get_cookies()
 
     res.result = challenge_res
     return res


### PR DESCRIPTION
Fixes #1652

## Summary
Cookies were being captured before the `waitInSeconds` sleep completed, causing cookies set during JavaScript execution after the initial page load to be missed in the response.

## Changes
- Moved `challenge_res.cookies = driver.get_cookies()` from before the wait block to after all waits and operations complete
- This ensures cookies set during the wait period (e.g., by JavaScript challenges that take time to complete) are properly captured

## Testing
- Verified Python syntax is valid
- The fix follows the logic suggested in the issue report - cookies are now retrieved after `waitInSeconds` completes

```
src/flaresolverr_service.py | 4 +++-
1 file changed, 3 insertions(+), 1 deletion(-)
```