### PR TITLE
Add experimental profile-backed browser launch overrides

### DIFF
--- a/RAWON_PROFILE_PATCH.md
+++ b/RAWON_PROFILE_PATCH.md
@@ -1,0 +1,69 @@
+# Rawon profile-backed FlareSolverr patch
+
+Patch lokal ini dibuat untuk kasus Cloudflare yang tidak cukup diselesaikan dengan cookie transplant biasa.
+
+## Masalah yang disasar
+
+Pada beberapa target seperti `chatgpt.com`, FlareSolverr standar bisa lolos di browser miliknya sendiri, tetapi clearance itu tidak otomatis nempel ke browser profile asli yang dipakai kerja sehari-hari.
+
+Akibatnya:
+- FlareSolverr terlihat sukses
+- tetapi profile Chrome asli masih mentok di `Just a moment...`
+
+## Tambahan fitur pada patch ini
+
+### 1. `userDataDir`
+Memaksa browser internal FlareSolverr memakai **folder profile Chrome asli**.
+
+Praktisnya:
+- FlareSolverr tidak lagi solve di profile sementara yang terpisah
+- dia solve langsung di profile target yang memang ingin dipulihkan
+
+### 2. `browserArgs`
+Mengizinkan argumen Chrome tambahan per request/session.
+
+Kegunaan:
+- eksperimen fingerprint
+- proxy flag tertentu
+- opsi browser tambahan tanpa edit source tiap kali
+
+### 3. `browserExecutablePath`
+Mengizinkan override path Chrome/Chromium.
+
+Kegunaan:
+- host yang punya binary non-standar
+- eksperimen pakai build browser tertentu
+
+### 4. `userAgent` override lokal
+Mengizinkan request/session memaksa UA tertentu pada browser yang diluncurkan FlareSolverr.
+
+Catatan:
+- ini patch lokal eksperimen
+- upstream FlareSolverr v2 tidak memakai request `userAgent` sebagai perilaku resmi default
+
+### 5. Session menyimpan launch settings
+Mode `sessions.create` sekarang menyimpan setting penting ini:
+- proxy
+- user agent
+- user data dir
+- browser args
+- browser executable path
+
+Artinya session berikutnya tetap konsisten dan tidak balik ke launch default.
+
+## Hasil yang sudah terbukti di Rawon
+
+### Gagal
+- cookie + UA transplant saja tidak cukup untuk beberapa profile ChatGPT
+
+### Berhasil
+- patched FlareSolverr + `userDataDir` profile asli berhasil membersihkan Cloudflare pada beberapa profile ChatGPT Rawon
+- untuk profile yang lebih bandel, mode session dua langkah juga berhasil:
+  - `sessions.create`
+  - `request.get`
+  - `request.get` lagi sampai `Challenge not detected!`
+  - `sessions.destroy`
+
+## Status
+
+Ini masih **patch eksperimen lokal**, belum upstream.

--- a/src/dtos.py
+++ b/src/dtos.py
@@ -37,7 +37,10 @@ class V1RequestBase(object):
     session: str = None
     session_ttl_minutes: int = None
     headers: list = None  # deprecated v2.0.0, not used
-    userAgent: str = None  # deprecated v2.0.0, not used
+    userAgent: str = None  # experimental override, supported in this local patch
+    userDataDir: str = None  # experimental override, Chrome user-data-dir path
+    browserArgs: list[str] | str | None = None  # experimental extra Chrome args
+    browserExecutablePath: str = None  # experimental Chrome path override
 
     # V1Request
     url: str = None

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -122,8 +122,6 @@ def _controller_v1_handler(req: V1RequestBase) -> V1ResponseBase:
         raise Exception("Request parameter 'cmd' is mandatory.")
     if req.headers is not None:
         logging.warning("Request parameter 'headers' was removed in FlareSolverr v2.")
-    if req.userAgent is not None:
-        logging.warning("Request parameter 'userAgent' was removed in FlareSolverr v2.")
 
     # set default values
     if req.maxTimeout is None or int(req.maxTimeout) < 1:
@@ -186,7 +184,14 @@ def _cmd_request_post(req: V1RequestBase) -> V1ResponseBase:
 def _cmd_sessions_create(req: V1RequestBase) -> V1ResponseBase:
     logging.debug("Creating new session...")
 
-    session, fresh = SESSIONS_STORAGE.create(session_id=req.session, proxy=req.proxy)
+    session, fresh = SESSIONS_STORAGE.create(
+        session_id=req.session,
+        proxy=req.proxy,
+        user_agent=req.userAgent,
+        user_data_dir=req.userDataDir,
+        browser_args=req.browserArgs,
+        browser_executable_path=req.browserExecutablePath,
+    )
     session_id = session.session_id
 
     if not fresh:
@@ -233,7 +238,15 @@ def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
         if req.session:
             session_id = req.session
             ttl = timedelta(minutes=req.session_ttl_minutes) if req.session_ttl_minutes else None
-            session, fresh = SESSIONS_STORAGE.get(session_id, ttl)
+            session, fresh = SESSIONS_STORAGE.get(
+                session_id,
+                ttl,
+                proxy=req.proxy,
+                user_agent=req.userAgent,
+                user_data_dir=req.userDataDir,
+                browser_args=req.browserArgs,
+                browser_executable_path=req.browserExecutablePath,
+            )
 
             if fresh:
                 logging.debug(f"new session created to perform the request (session_id={session_id})")
@@ -243,7 +256,13 @@ def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
 
             driver = session.driver
         else:
-            driver = utils.get_webdriver(req.proxy)
+            driver = utils.get_webdriver(
+                proxy=req.proxy,
+                user_agent=req.userAgent,
+                user_data_dir=req.userDataDir,
+                browser_args=req.browserArgs,
+                browser_executable_path=req.browserExecutablePath,
+            )
             logging.debug('New instance of webdriver has been created to perform the request')
         return func_timeout(timeout, _evil_logic, (req, driver, method))
     except FunctionTimedOut:

--- a/src/sessions.py
+++ b/src/sessions.py
@@ -14,6 +14,11 @@ class Session:
     session_id: str
     driver: WebDriver
     created_at: datetime
+    proxy: Optional[dict] = None
+    user_agent: Optional[str] = None
+    user_data_dir: Optional[str] = None
+    browser_args: Optional[list] = None
+    browser_executable_path: Optional[str] = None
 
     def lifetime(self) -> timedelta:
         return datetime.now() - self.created_at
@@ -26,6 +31,8 @@ class SessionsStorage:
         self.sessions = {}
 
     def create(self, session_id: Optional[str] = None, proxy: Optional[dict] = None,
+               user_agent: Optional[str] = None, user_data_dir: Optional[str] = None,
+               browser_args: Optional[list] = None, browser_executable_path: Optional[str] = None,
                force_new: Optional[bool] = False) -> Tuple[Session, bool]:
         """create creates new instance of WebDriver if necessary,
         assign defined (or newly generated) session_id to the instance
@@ -45,9 +52,12 @@ class SessionsStorage:
         if self.exists(session_id):
             return self.sessions[session_id], False
 
-        driver = utils.get_webdriver(proxy)
+        driver = utils.get_webdriver(proxy=proxy, user_agent=user_agent, user_data_dir=user_data_dir,
+                                     browser_args=browser_args, browser_executable_path=browser_executable_path)
         created_at = datetime.now()
-        session = Session(session_id, driver, created_at)
+        session = Session(session_id, driver, created_at, proxy=proxy, user_agent=user_agent,
+                          user_data_dir=user_data_dir, browser_args=browser_args,
+                          browser_executable_path=browser_executable_path)
 
         self.sessions[session_id] = session
 
@@ -71,12 +81,27 @@ class SessionsStorage:
         session.driver.quit()
         return True
 
-    def get(self, session_id: str, ttl: Optional[timedelta] = None) -> Tuple[Session, bool]:
-        session, fresh = self.create(session_id)
+    def get(self, session_id: str, ttl: Optional[timedelta] = None,
+            proxy: Optional[dict] = None, user_agent: Optional[str] = None,
+            user_data_dir: Optional[str] = None, browser_args: Optional[list] = None,
+            browser_executable_path: Optional[str] = None) -> Tuple[Session, bool]:
+        existing = self.sessions.get(session_id)
+        if existing is not None:
+            proxy = existing.proxy
+            user_agent = existing.user_agent
+            user_data_dir = existing.user_data_dir
+            browser_args = existing.browser_args
+            browser_executable_path = existing.browser_executable_path
+
+        session, fresh = self.create(session_id, proxy=proxy, user_agent=user_agent,
+                                     user_data_dir=user_data_dir, browser_args=browser_args,
+                                     browser_executable_path=browser_executable_path)
 
         if ttl is not None and not fresh and session.lifetime() > ttl:
             logging.debug(f'session\'s lifetime has expired, so the session is recreated (session_id={session_id})')
-            session, fresh = self.create(session_id, force_new=True)
+            session, fresh = self.create(session_id, proxy=proxy, user_agent=user_agent,
+                                         user_data_dir=user_data_dir, browser_args=browser_args,
+                                         browser_executable_path=browser_executable_path, force_new=True)
 
         return session, fresh
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -129,9 +129,23 @@ def create_proxy_extension(proxy: dict) -> str:
     return proxy_extension_dir
 
 
-def get_webdriver(proxy: dict = None) -> WebDriver:
+def _normalize_browser_args(browser_args) -> list[str]:
+    if browser_args is None:
+        return []
+    if isinstance(browser_args, str):
+        return [browser_args]
+    if isinstance(browser_args, (list, tuple)):
+        return [str(arg) for arg in browser_args if arg is not None and str(arg).strip() != '']
+    raise Exception("browserArgs must be a string or list of strings")
+
+
+def get_webdriver(proxy: dict = None, user_agent: str = None, user_data_dir: str = None,
+                  browser_args=None, browser_executable_path: str = None) -> WebDriver:
     global PATCHED_DRIVER_PATH, USER_AGENT
     logging.debug('Launching web browser...')
+
+    requested_user_agent = user_agent or USER_AGENT
+    extra_browser_args = _normalize_browser_args(browser_args)
 
     # undetected_chromedriver
     options = uc.ChromeOptions()
@@ -154,9 +168,14 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     if language is not None:
         options.add_argument('--accept-lang=%s' % language)
 
-    # Fix for Chrome 117 | https://github.com/FlareSolverr/FlareSolverr/issues/910
-    if USER_AGENT is not None:
-        options.add_argument('--user-agent=%s' % USER_AGENT)
+    if requested_user_agent is not None:
+        options.add_argument('--user-agent=%s' % requested_user_agent)
+
+    if user_data_dir is not None:
+        options.add_argument('--user-data-dir=%s' % user_data_dir)
+
+    for arg in extra_browser_args:
+        options.add_argument(arg)
 
     proxy_extension_dir = None
     if proxy and all(key in proxy for key in ['url', 'username', 'password']):
@@ -191,7 +210,7 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
             driver_exe_path = PATCHED_DRIVER_PATH
 
     # detect chrome path
-    browser_executable_path = get_chrome_exe_path()
+    browser_executable_path = browser_executable_path or get_chrome_exe_path()
 
     # downloads and patches the chromedriver
     # if we don't set driver_executable_path it downloads, patches, and deletes the driver each time


### PR DESCRIPTION
## Summary

This PR adds opt-in browser launch overrides that make it possible to drive FlareSolverr against a real saved browser profile when cookie transfer alone is not enough.

### Added request/session fields
- `userDataDir`
- `browserArgs`
- `browserExecutablePath`
- `userAgent` (local experimental override)

### Internal changes
- `utils.get_webdriver()` now accepts launch overrides for user data dir, extra browser args, executable path, and user agent
- `sessions.py` now persists launch settings so session reuse/recreation stays consistent
- `flaresolverr_service.py` threads the new fields through both direct requests and `sessions.create`
- added `RAWON_PROFILE_PATCH.md` to document the motivation and local experiment results

## Why

In local testing on a CPU VPS, standard FlareSolverr could solve Cloudflare in its own isolated browser, but some remembered Chrome profiles still stayed on `Just a moment...` after cookie + user-agent transplant.

Using the same profile directory directly through the browser that FlareSolverr launches worked better:
- one-shot `request.get` with the real `userDataDir` cleared Cloudflare for some profiles
- stickier profiles needed a session-based double pass:
  - `sessions.create`
  - `request.get`
  - `request.get` again until challenge was no longer detected
  - `sessions.destroy`

## Notes

- This is intentionally opt-in and does not change default behavior when these fields are omitted.
- The `userAgent` field is marked as experimental here because upstream v2 currently treats request-level `userAgent` as removed.
- The extra markdown file is included to capture the experiment context and could be dropped if maintainers prefer a smaller PR.

## Local verification

Verified locally against Cloudflare-gated `chatgpt.com` profiles on Rawon:
- cookie transplant only: insufficient for some real profiles
- patched `userDataDir` flow: Cloudflare clearance persisted into the real profile and later real-Chrome rechecks no longer showed `Just a moment...`
