### PR TITLE
fix: preserve numeric types when postData is JSON

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import platform
 import sys
@@ -487,9 +488,22 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
 
 
 def _post_request(req: V1RequestBase, driver: WebDriver):
+    post_data = req.postData if req.postData and req.postData[0] != '?' else req.postData[1:] if req.postData else ''
+
+    # If postData is valid JSON, use fetch() with application/json to preserve
+    # numeric and boolean types. Form-encoded POST converts all values to strings,
+    # which breaks APIs that require numbers (e.g. feeRate: 50 becomes "50").
+    stripped = post_data.strip()
+    if stripped.startswith(('{', '[')):
+        try:
+            json.loads(stripped)
+            _json_post_request(req, driver, stripped)
+            return
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to form-encoded approach
+
     post_form = f'<form id="hackForm" action="{req.url}" method="POST">'
-    query_string = req.postData if req.postData and req.postData[0] != '?' else req.postData[1:] if req.postData else ''
-    pairs = query_string.split('&')
+    pairs = post_data.split('&')
     for pair in pairs:
         parts = pair.split('=', 1)
         # noinspection PyBroadException
@@ -517,3 +531,35 @@ def _post_request(req: V1RequestBase, driver: WebDriver):
         </body>
         </html>"""
     driver.get("data:text/html;charset=utf-8,{html_content}".format(html_content=html_content))
+
+
+def _json_post_request(req: V1RequestBase, driver: WebDriver, post_data: str):
+    """Send a JSON POST using fetch() so numeric/boolean types are preserved.
+
+    Navigates to the target URL first (GET) to establish a same-origin context,
+    which allows the subsequent fetch() to bypass CORS restrictions.
+    The fetch response overwrites the page so driver.page_source contains it.
+    """
+    logging.debug("JSON postData detected, using fetch() with Content-Type: application/json")
+    driver.get(req.url)
+
+    script = """
+        var callback = arguments[arguments.length - 1];
+        fetch(arguments[0], {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: arguments[1]
+        }).then(function(response) {
+            return response.text().then(function(text) {
+                document.open();
+                document.write(text);
+                document.close();
+                callback('ok');
+            });
+        }).catch(function(e) {
+            callback('error: ' + e.message);
+        });
+    """
+    result = driver.execute_async_script(script, req.url, post_data)
+    if result and result.startswith('error:'):
+        logging.warning("JSON POST fetch() failed: %s", result)


### PR DESCRIPTION
## Problem

When `postData` is forwarded as `application/x-www-form-urlencoded` via the HTML form approach, **all values become strings**. APIs that require numbers (e.g. `feeRate: 50`) receive `"50"` and return a type validation error:

```
orders.0.feeRate must be a number conforming to the specified constraints
```

This affects any JSON API that type-checks its input — the user has no workaround since the form encoding is unconditional.

## Root cause

`_post_request` always generates `<input type="text">` elements and submits via an HTML form. HTTP form submission is inherently `application/x-www-form-urlencoded`, which has no concept of types — every value is a string.

## Fix

When `postData` is detected as valid JSON (starts with `{` or `[` and parses cleanly), a new `_json_post_request` helper is used instead:

1. **Navigate to the target URL (GET)** — establishes a same-origin browser context
2. **Execute `fetch()` via `execute_async_script`** — sends `Content-Type: application/json` with the original JSON body, preserving all types
3. **`document.write()` the response** — overwrites the page so `driver.page_source` contains the POST response, same as the form approach

The same-origin context from step 1 means the `fetch()` bypasses CORS restrictions without needing any special headers from the target server.

URL-encoded `postData` continues to use the existing HTML form approach unchanged.

## Behaviour

| postData | Content-Type sent | Types preserved |
|----------|-------------------|-----------------|
| `key=value&num=50` | `application/x-www-form-urlencoded` | ❌ strings only (unchanged) |
| `{"num": 50, "flag": true}` | `application/json` | ✅ number, boolean, null |

## Related issues

Closes #777  
Closes #1194

🤖 Generated with [Claude Code](https://claude.com/claude-code)