### PR TITLE
fix: warn on low temp disk space and clean up stale Chrome profiles on startup

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -61,6 +61,9 @@ def test_browser_installation():
     logging.info("Testing web browser installation...")
     logging.info("Platform: " + platform.platform())
 
+    utils.cleanup_stale_temp_dirs()
+    utils.check_disk_space()
+
     chrome_exe_path = utils.get_chrome_exe_path()
     if chrome_exe_path is None:
         logging.error("Chrome / Chromium web browser not installed!")

--- a/src/utils.py
+++ b/src/utils.py
@@ -312,6 +312,73 @@ def extract_version_nt_folder() -> str:
     return ''
 
 
+def check_disk_space():
+    """Warn when the temp directory is running low on free space.
+
+    Chrome writes large temporary profiles to the system temp directory.
+    When the partition is full Chrome crashes with a cryptic
+    'disconnected: Unable to receive message from renderer' error that
+    gives no hint about the real cause.
+    """
+    tmp_dir = tempfile.gettempdir()
+    try:
+        usage = shutil.disk_usage(tmp_dir)
+        free_mb = usage.free / (1024 * 1024)
+        total_mb = usage.total / (1024 * 1024)
+        pct_used = 100 * (usage.used / usage.total)
+        logging.debug("Temp directory '%s': %.0f MB free of %.0f MB total (%.0f%% used)",
+                      tmp_dir, free_mb, total_mb, pct_used)
+        if usage.free == 0:
+            logging.error(
+                "Temp directory '%s' is completely full (%.0f MB used of %.0f MB). "
+                "Chrome cannot start. Free up space or set TMPDIR to a partition "
+                "with sufficient free space.",
+                tmp_dir, usage.used / (1024 * 1024), total_mb
+            )
+        elif free_mb < 500:
+            logging.warning(
+                "Temp directory '%s' has only %.0f MB free. "
+                "Chrome may fail to start or crash. "
+                "Consider freeing space or setting TMPDIR to another partition.",
+                tmp_dir, free_mb
+            )
+    except Exception as e:
+        logging.debug("Could not check temp directory disk space: %s", e)
+
+
+def cleanup_stale_temp_dirs():
+    """Remove leftover Chrome/FlareSolverr temp directories from previous sessions.
+
+    Chrome creates profile directories in the system temp folder and removes
+    them on clean shutdown. When FlareSolverr is killed or crashes these
+    directories are never cleaned up, gradually filling the partition.
+    """
+    tmp_dir = tempfile.gettempdir()
+    prefixes = (
+        'puppeteer_dev_chrome_profile-',
+        'puppeteer_dev_profile-',
+    )
+    removed = 0
+    errors = 0
+    try:
+        for entry in os.scandir(tmp_dir):
+            if entry.is_dir(follow_symlinks=False) and any(
+                entry.name.startswith(p) for p in prefixes
+            ):
+                try:
+                    shutil.rmtree(entry.path, ignore_errors=True)
+                    removed += 1
+                except Exception:
+                    errors += 1
+    except Exception as e:
+        logging.debug("Could not scan temp directory for stale profiles: %s", e)
+        return
+    if removed:
+        logging.info("Cleaned up %d stale Chrome temp director%s from '%s'%s",
+                     removed, 'ies' if removed != 1 else 'y', tmp_dir,
+                     f" ({errors} could not be removed)" if errors else "")
+
+
 def get_user_agent(driver=None) -> str:
     global USER_AGENT
     if USER_AGENT is not None:


### PR DESCRIPTION
## Problem

When the `/tmp` partition fills up, Chrome crashes with:

```
selenium.common.exceptions.WebDriverException: Message: disconnected: Unable to receive message from renderer
  (failed to check if window was closed: disconnected: not connected to DevTools)
```

This error gives absolutely no hint that the real cause is a full disk. As documented in #924, one user spent **two full days** investigating Chrome versions, proxies, and Docker configurations before discovering `/tmp` was at 100%.

A secondary cause of the fill-up: Chrome creates `puppeteer_dev_chrome_profile-*` profile directories in the temp folder and removes them on clean shutdown. When FlareSolverr is killed or crashes, hundreds of these accumulate and the partition fills gradually.

## Fix

Two functions added to `utils.py`, both called from `test_browser_installation()` at startup:

### 1. `check_disk_space()`
Checks free space on the temp directory partition before Chrome launches:
- **Full (0 bytes free)** → `ERROR` with the partition path, sizes, and a hint to set `TMPDIR`
- **< 500 MB free** → `WARNING` with free space and the same suggestion
- **Otherwise** → `DEBUG` log only (no noise in normal operation)

```
ERROR Temp directory '/tmp' is completely full (2048 MB used of 2048 MB).
      Chrome cannot start. Free up space or set TMPDIR to a partition with sufficient free space.
```

### 2. `cleanup_stale_temp_dirs()`
On startup, removes leftover `puppeteer_dev_chrome_profile-*` and `puppeteer_dev_profile-*` directories from previous crashed sessions. Logs how many were cleaned up (silent if none found). Both functions catch all exceptions and fall through gracefully — they cannot break existing behaviour.

## Related

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)