### PR TITLE
Add HIDE_WINDOW option to hide the browser window on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ This works like `request.get`, with the addition of the postData parameter. Note
 | TZ                 | UTC                    | Timezone used in the logs and the web browser. Example: `TZ=Europe/London`.                                                              |
 | LANG               | none                   | Language used in the web browser. Example: `LANG=en_GB`.                                                                                 |
 | HEADLESS           | true                   | Only for debugging. To run the web browser in headless mode or visible.                                                                  |
+| HIDE_WINDOW        | true                   | Windows only. When running head-full (`HEADLESS=false`), hides the browser window so it does not pop up. Set `false` to show it.          |
 | DISABLE_MEDIA      | false                  | To disable loading images, CSS, and other media in the web browser to save network bandwidth.                                            |
 | TEST_URL           | https://www.google.com | FlareSolverr makes a request on start to make sure the web browser is working. You can change that URL if it is blocked in your country. |
 | PORT               | 8191                   | Listening port. You don't need to change this if you are running on Docker.                                                              |

--- a/src/utils.py
+++ b/src/utils.py
@@ -28,6 +28,12 @@ def get_config_headless() -> bool:
     return os.environ.get('HEADLESS', 'true').lower() == 'true'
 
 
+def get_config_hide_window() -> bool:
+    # When running head-full on Windows (HEADLESS=false), hide the browser window
+    # so it does not pop up. Enabled by default; set HIDE_WINDOW=false to show it.
+    return os.environ.get('HIDE_WINDOW', 'true').lower() == 'true'
+
+
 def get_config_disable_media() -> bool:
     return os.environ.get('DISABLE_MEDIA', 'false').lower() == 'true'
 
@@ -170,14 +176,20 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
         logging.debug("Using webdriver proxy: %s", proxy_url)
         options.add_argument('--proxy-server=%s' % proxy_url)
 
-    # note: headless mode is detected (headless = True)
-    # we launch the browser in head-full mode with the window hidden
+    # note: real headless mode (headless = True) is detected by Cloudflare
+    # we launch the browser in head-full mode with the window hidden instead
     windows_headless = False
     if get_config_headless():
         if os.name == 'nt':
             windows_headless = True
         else:
             start_xvfb_display()
+    elif os.name == 'nt' and get_config_hide_window():
+        # Head-full mode is required to solve Cloudflare challenges, but on Windows
+        # the browser window can still be hidden (launched with SW_HIDE) so it does
+        # not pop up. Synthetic input via the devtools protocol still works while the
+        # window is hidden, so challenge solving is unaffected.
+        windows_headless = True
     # For normal headless mode:
     # options.add_argument('--headless')
 


### PR DESCRIPTION
## What

Adds a `HIDE_WINDOW` option (Windows only, default `true`) so the browser window does not pop up when running head-full (`HEADLESS=false`).

## Why

Cloudflare detects real headless Chrome, so solving Turnstile / checkbox challenges requires running head-full. The downside is a visible Chrome window on every request, which is disruptive when FlareSolverr runs as a background service.

## How it differs from `HEADLESS`

Two independent settings are passed to the browser ([utils.py#L213-L215](https://github.com/johnpreed/FlareSolverr/blob/f92e2a4d0070bb38ee0b246429813c45d43fbe8f/src/utils.py#L213-L215)):

- `headless` — adds Chrome's `--headless=new` flag ([__init__.py#L399](https://github.com/FlareSolverr/FlareSolverr/blob/b21642624b333946848bfa2d5f26d5536dd64451/src/undetected_chromedriver/__init__.py#L399)). This is what Cloudflare detects. Sourced from the `HEADLESS` env var ([flaresolverr.py#L92](https://github.com/FlareSolverr/FlareSolverr/blob/b21642624b333946848bfa2d5f26d5536dd64451/src/flaresolverr.py#L92)).
- `windows_headless` — launches the process with the OS window hidden (`SW_HIDE`, [__init__.py#L455-L466](https://github.com/FlareSolverr/FlareSolverr/blob/b21642624b333946848bfa2d5f26d5536dd64451/src/undetected_chromedriver/__init__.py#L455-L466)). Does **not** affect what Chrome reports.

Both are passed on the same line, but only `headless` controls the `--headless` flag. `HIDE_WINDOW` enables only `windows_headless`, so the result is a normal, fully-rendered Chrome that simply has no visible window — not a headless browser.

| `HEADLESS` | `HIDE_WINDOW` | `--headless` flag | Window | Solves challenges |
| --- | --- | --- | --- | --- |
| `true` | (n/a) | yes | hidden | no (detected) |
| `false` | `true` (default) | no | hidden | yes |
| `false` | `false` | no | visible | yes |

Challenge solving is unaffected because the checkbox input is injected through the automation interface, not the OS input queue, so a hidden window does not block it.

## Changes

- `src/utils.py` — add `get_config_hide_window()` and enable `windows_headless` when running head-full on Windows.
- `README.md` — document the `HIDE_WINDOW` variable.

- Fixes #1737