### PR TITLE
feat: add executeJs / trusted click to run JavaScript on the solved page

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ session. When you no longer need to use a session you should make sure to close 
 | waitInSeconds       | Optional, default none. Length to wait in seconds after solving the challenge, and before returning the results. Useful to allow it to load dynamic content.                                                                                                                                                                                 |
 | disableMedia        | Optional, default false. When true FlareSolverr will prevent media resources (images, CSS, and fonts) from being loaded to speed up navigation.                                                                                                                                                                                              |
 | tabs_till_verify    | Optional, default none. Number of times the `Tab` button is needed to be pressed to end up on the turnstile captcha, in order to verify it. After verifying the captcha, the result will be stored in the solution under `turnstile_token`.                                                                                                  |
-| executeJs           | Optional, default none. JavaScript to run on the page after the challenge is solved. The snippet may `return` a value or a `Promise` (which is awaited); the result is returned as a string in the `executeJsResult` field of the solution. Bounded by `EXECUTE_JS_TIMEOUT` seconds (default 20). Useful for reading post-challenge state or driving an in-page action that must run in the solved browser context. Eg: `"executeJs": "return document.title;"` |
 
 > **Warning**
 > If you want to use Cloudflare clearance cookie in your scripts, make sure you use the FlareSolverr User-Agent too. If they don't match you will see the challenge.
@@ -296,7 +295,6 @@ This works like `request.get`, with the addition of the postData parameter. Note
 | HOST               | 0.0.0.0                | Listening interface. You don't need to change this if you are running on Docker.                                                         |
 | PROMETHEUS_ENABLED | false                  | Enable Prometheus exporter. See the Prometheus section below.                                                                            |
 | PROMETHEUS_PORT    | 8192                   | Listening port for Prometheus exporter. See the Prometheus section below.                                                                |
-| EXECUTE_JS_TIMEOUT | 20                     | Max seconds an `executeJs` snippet may run before it is abandoned.                                                                       |
 
 Environment variables are set differently depending on the operating system. Some examples:
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ session. When you no longer need to use a session you should make sure to close 
 | waitInSeconds       | Optional, default none. Length to wait in seconds after solving the challenge, and before returning the results. Useful to allow it to load dynamic content.                                                                                                                                                                                 |
 | disableMedia        | Optional, default false. When true FlareSolverr will prevent media resources (images, CSS, and fonts) from being loaded to speed up navigation.                                                                                                                                                                                              |
 | tabs_till_verify    | Optional, default none. Number of times the `Tab` button is needed to be pressed to end up on the turnstile captcha, in order to verify it. After verifying the captcha, the result will be stored in the solution under `turnstile_token`.                                                                                                  |
+| executeJs           | Optional, default none. JavaScript to run on the page after the challenge is solved. The snippet may `return` a value or a `Promise` (which is awaited); the result is returned as a string in the `executeJsResult` field of the solution. Bounded by `EXECUTE_JS_TIMEOUT` seconds (default 20). Useful for reading post-challenge state or driving an in-page action that must run in the solved browser context. Eg: `"executeJs": "return document.title;"` |
 
 > **Warning**
 > If you want to use Cloudflare clearance cookie in your scripts, make sure you use the FlareSolverr User-Agent too. If they don't match you will see the challenge.
@@ -295,6 +296,7 @@ This works like `request.get`, with the addition of the postData parameter. Note
 | HOST               | 0.0.0.0                | Listening interface. You don't need to change this if you are running on Docker.                                                         |
 | PROMETHEUS_ENABLED | false                  | Enable Prometheus exporter. See the Prometheus section below.                                                                            |
 | PROMETHEUS_PORT    | 8192                   | Listening port for Prometheus exporter. See the Prometheus section below.                                                                |
+| EXECUTE_JS_TIMEOUT | 20                     | Max seconds an `executeJs` snippet may run before it is abandoned.                                                                       |
 
 Environment variables are set differently depending on the operating system. Some examples:
 

--- a/src/dtos.py
+++ b/src/dtos.py
@@ -55,6 +55,14 @@ class V1RequestBase(object):
     # optional JS to run on the solved page; result returned as solution.executeJsResult.
     # May `return` a value or a Promise (awaited). Bounded by EXECUTE_JS_TIMEOUT seconds.
     executeJs: str = None
+    # optional: drive a *trusted* (isTrusted=true) mouse click via CDP Input events,
+    # which JS-dispatched events cannot fake. When true, executeJs runs as a two-phase
+    # "arm" script: it installs its hooks, sets window.__FRS_AWAIT to a Promise, and
+    # returns JSON {"trustedClick":{"x":<cssPx>,"y":<cssPx>}} naming the viewport point
+    # to click. FlareSolverr then dispatches a human-like trusted pointer approach +
+    # click at that point and awaits window.__FRS_AWAIT, returning its resolved value
+    # as executeJsResult. Used for pointer-trust captchas (e.g. Filecrypt PoW).
+    trustedClick: bool = None
 
     def __init__(self, _dict):
         self.__dict__.update(_dict)

--- a/src/dtos.py
+++ b/src/dtos.py
@@ -12,6 +12,7 @@ class ChallengeResolutionResultT:
     userAgent: str = None
     screenshot: str | None = None
     turnstile_token: str = None
+    executeJsResult: str = None  # result of the optional executeJs script
 
     def __init__(self, _dict):
         self.__dict__.update(_dict)
@@ -51,6 +52,9 @@ class V1RequestBase(object):
     disableMedia: bool = None
     # Optional when you've got a turnstile captcha that needs to be clicked after X number of Tab presses
     tabs_till_verify : int = None
+    # optional JS to run on the solved page; result returned as solution.executeJsResult.
+    # May `return` a value or a Promise (awaited). Bounded by EXECUTE_JS_TIMEOUT seconds.
+    executeJs: str = None
 
     def __init__(self, _dict):
         self.__dict__.update(_dict)

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -491,6 +491,10 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
 
     if req.executeJs:
         challenge_res.executeJsResult = _execute_js(driver, req.executeJs)
+        # executeJs may set or refresh cookies (e.g. completing an in-page step).
+        # The cookie jar captured above is now stale, so re-snapshot it; otherwise
+        # a caller that re-fetches with the returned cookies sees the pre-action page.
+        challenge_res.cookies = driver.get_cookies()
 
     res.result = challenge_res
     return res

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -1,6 +1,8 @@
+import json
 import logging
 import os
 import platform
+import random
 import sys
 import time
 from datetime import timedelta
@@ -28,6 +30,15 @@ try:
     EXECUTE_JS_TIMEOUT = int(os.environ.get('EXECUTE_JS_TIMEOUT', '20'))
 except ValueError:
     EXECUTE_JS_TIMEOUT = 10
+
+# max seconds to await the page Promise in trustedClick mode. Larger than
+# EXECUTE_JS_TIMEOUT because a trusted-click proof-of-work solve may legitimately
+# run tens of seconds (an escalated difficulty-20 challenge), whereas a plain
+# executeJs script is expected to return quickly.
+try:
+    TRUSTED_CLICK_TIMEOUT = int(os.environ.get('TRUSTED_CLICK_TIMEOUT', '90'))
+except ValueError:
+    TRUSTED_CLICK_TIMEOUT = 90
 
 ACCESS_DENIED_TITLES = [
     # Cloudflare
@@ -490,7 +501,10 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
         challenge_res.screenshot = driver.get_screenshot_as_base64()
 
     if req.executeJs:
-        challenge_res.executeJsResult = _execute_js(driver, req.executeJs)
+        if req.trustedClick:
+            challenge_res.executeJsResult = _execute_js_trusted_click(driver, req.executeJs)
+        else:
+            challenge_res.executeJsResult = _execute_js(driver, req.executeJs)
         # executeJs may set or refresh cookies (e.g. completing an in-page step).
         # The cookie jar captured above is now stale, so re-snapshot it; otherwise
         # a caller that re-fetches with the returned cookies sees the pre-action page.
@@ -521,6 +535,87 @@ def _execute_js(driver: WebDriver, script: str) -> str:
         })
     except Exception as e:
         logging.warning("executeJs failed: " + str(e))
+        return "EXECUTE_JS_ERROR: " + str(e)
+
+    exc = res.get('exceptionDetails')
+    if exc:
+        msg = exc.get('exception', {}).get('description') or exc.get('text') or 'exception'
+        return "EXECUTE_JS_ERROR: " + str(msg)
+    value = res.get('result', {}).get('value')
+    return str(value) if value is not None else ""
+
+
+def _trusted_pointer_gesture(driver: WebDriver, x: float, y: float) -> None:
+    """Move the mouse to (x, y) along a human-like path and click, using CDP
+    Input.dispatchMouseEvent. Unlike JS-dispatched events these carry
+    isTrusted=true, which pointer-trust captchas (e.g. Filecrypt's PoW signer)
+    require. Coordinates are viewport CSS pixels (deviceScaleFactor 1)."""
+    def mouse(kind, mx, my, button='none', buttons=0, click_count=0):
+        # Integer coordinates: a real mouse reports whole-pixel positions, and the
+        # pointer-trust signer rejects the fractional deltas that interpolation
+        # would otherwise produce.
+        driver.execute_cdp_cmd('Input.dispatchMouseEvent', {
+            'type': kind, 'x': round(mx), 'y': round(my),
+            'button': button, 'buttons': buttons,
+            'clickCount': click_count, 'pointerType': 'mouse',
+        })
+
+    x, y = round(x), round(y)
+    start_x = x - random.uniform(120, 180)
+    start_y = y - random.uniform(90, 150)
+    steps = random.randint(22, 30)
+    for i in range(1, steps + 1):
+        t = i / steps
+        # ease-in-out so the pointer accelerates then settles onto the target
+        te = 2 * t * t if t < 0.5 else -1 + (4 - 2 * t) * t
+        mx = start_x + (x - start_x) * te + random.uniform(-1.5, 1.5)
+        my = start_y + (y - start_y) * te + random.uniform(-1.5, 1.5)
+        mouse('mouseMoved', mx, my)
+        time.sleep(random.uniform(0.006, 0.015))
+    mouse('mouseMoved', x, y)
+    time.sleep(random.uniform(0.03, 0.08))
+    mouse('mousePressed', x, y, button='left', buttons=1, click_count=1)
+    time.sleep(random.uniform(0.06, 0.14))
+    mouse('mouseReleased', x, y, button='left', buttons=0, click_count=1)
+
+
+def _execute_js_trusted_click(driver: WebDriver, script: str) -> str:
+    """Two-phase executeJs that injects a *trusted* click between arm and await.
+
+    Phase 1 (arm): run the caller's script, which installs its hooks, assigns
+    ``window.__FRS_AWAIT`` (a Promise resolved when the in-page action completes),
+    and returns ``{"trustedClick":{"x":<cssPx>,"y":<cssPx>}}``. Phase 2: dispatch a
+    trusted pointer approach + click at that point via CDP. Phase 3 (await): resolve
+    ``window.__FRS_AWAIT`` and return its value. Bounded by EXECUTE_JS_TIMEOUT."""
+    # Keep the page in the foreground and treated as focused: an occluded/blurred
+    # renderer is background-throttled, which starves in-page proof-of-work workers.
+    for cmd, params in (('Page.bringToFront', {}),
+                        ('Emulation.setFocusEmulationEnabled', {'enabled': True})):
+        try:
+            driver.execute_cdp_cmd(cmd, params)
+        except Exception:
+            pass
+
+    arm = _execute_js(driver, script)
+    if arm.startswith("EXECUTE_JS_ERROR"):
+        return arm
+    try:
+        coords = (json.loads(arm) or {}).get('trustedClick')
+        cx, cy = float(coords['x']), float(coords['y'])
+    except Exception:
+        return "EXECUTE_JS_ERROR: trustedClick arm script did not return {trustedClick:{x,y}}: " + arm[:200]
+
+    _trusted_pointer_gesture(driver, cx, cy)
+
+    try:
+        res = driver.execute_cdp_cmd('Runtime.evaluate', {
+            'expression': "(() => window.__FRS_AWAIT)()",
+            'awaitPromise': True,
+            'returnByValue': True,
+            'timeout': TRUSTED_CLICK_TIMEOUT * 1000,
+        })
+    except Exception as e:
+        logging.warning("executeJs (trusted await) failed: " + str(e))
         return "EXECUTE_JS_ERROR: " + str(e)
 
     exc = res.get('exceptionDetails')

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -113,9 +113,24 @@ def health_endpoint() -> HealthResponse:
     return res
 
 
+def _redact_for_log(obj):
+    """Recursively replace bulky executeJs/executeJsResult string values with a
+    short size placeholder so request/response logs don't dump the whole script or
+    the returned page HTML."""
+    if isinstance(obj, dict):
+        return {
+            k: (f"<{len(v)} chars>" if k in ('executeJs', 'executeJsResult') and isinstance(v, str)
+                else _redact_for_log(v))
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_redact_for_log(x) for x in obj]
+    return obj
+
+
 def controller_v1_endpoint(req: V1RequestBase) -> V1ResponseBase:
     start_ts = int(time.time() * 1000)
-    logging.info(f"Incoming request => POST /v1 body: {utils.object_to_dict(req)}")
+    logging.info(f"Incoming request => POST /v1 body: {_redact_for_log(utils.object_to_dict(req))}")
     res: V1ResponseBase
     try:
         res = _controller_v1_handler(req)
@@ -129,7 +144,7 @@ def controller_v1_endpoint(req: V1RequestBase) -> V1ResponseBase:
     res.startTimestamp = start_ts
     res.endTimestamp = int(time.time() * 1000)
     res.version = utils.get_flaresolverr_version()
-    logging.debug(f"Response => POST /v1 body: {utils.object_to_dict(res)}")
+    logging.debug(f"Response => POST /v1 body: {_redact_for_log(utils.object_to_dict(res))}")
     logging.info(f"Response in {(res.endTimestamp - res.startTimestamp) / 1000} s")
     return res
 

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import platform
 import sys
 import time
@@ -21,6 +22,12 @@ from dtos import (STATUS_ERROR, STATUS_OK, ChallengeResolutionResultT,
                   ChallengeResolutionT, HealthResponse, IndexResponse,
                   V1RequestBase, V1ResponseBase)
 from sessions import SessionsStorage
+
+# max seconds an executeJs script may run before it is abandoned.
+try:
+    EXECUTE_JS_TIMEOUT = int(os.environ.get('EXECUTE_JS_TIMEOUT', '20'))
+except ValueError:
+    EXECUTE_JS_TIMEOUT = 10
 
 ACCESS_DENIED_TITLES = [
     # Cloudflare
@@ -482,8 +489,42 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
     if req.returnScreenshot:
         challenge_res.screenshot = driver.get_screenshot_as_base64()
 
+    if req.executeJs:
+        challenge_res.executeJsResult = _execute_js(driver, req.executeJs)
+
     res.result = challenge_res
     return res
+
+
+def _execute_js(driver: WebDriver, script: str) -> str:
+    """Run user-supplied JS on the solved page and return its result
+    as a string. The script may `return` a value or a Promise (awaited).
+
+    It evaluates `(() => { <script> })()` through
+    CDP `Runtime.evaluate` with `awaitPromise=true` in the page's real main-world event
+    loop, instead of Selenium's `execute_async_script`. The CDP path is what lets an
+    in-page web worker (e.g. a proof-of-work worker started by the script) actually run
+    and the returned Promise resolve — the async-script callback path did not. Bounded by
+    EXECUTE_JS_TIMEOUT so a hung script cannot block the response."""
+    expression = "(() => { " + script + "\n})()"
+    try:
+        res = driver.execute_cdp_cmd('Runtime.evaluate', {
+            'expression': expression,
+            'awaitPromise': True,
+            'returnByValue': True,
+            'userGesture': True,
+            'timeout': EXECUTE_JS_TIMEOUT * 1000,
+        })
+    except Exception as e:
+        logging.warning("executeJs failed: " + str(e))
+        return "EXECUTE_JS_ERROR: " + str(e)
+
+    exc = res.get('exceptionDetails')
+    if exc:
+        msg = exc.get('exception', {}).get('description') or exc.get('text') or 'exception'
+        return "EXECUTE_JS_ERROR: " + str(msg)
+    value = res.get('result', {}).get('value')
+    return str(value) if value is not None else ""
 
 
 def _post_request(req: V1RequestBase, driver: WebDriver):

--- a/src/utils.py
+++ b/src/utils.py
@@ -141,6 +141,12 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     # todo: this param shows a warning in chrome head-full
     options.add_argument('--disable-setuid-sandbox')
     options.add_argument('--disable-dev-shm-usage')
+    # Disable V8's Maglev mid-tier JIT. Since ~Chrome 138, Maglev runs some
+    # integer/typed-array-heavy web worker code (e.g. an in-page proof-of-work
+    # hashing loop driven via executeJs) ~40x slower than the TurboFan tier, so
+    # such a worker may never finish within maxTimeout. Chromium 136 (Maglev off
+    # by default) is unaffected; --no-maglev restores full speed on 138+.
+    options.add_argument('--js-flags=--no-maglev')
     # this option removes the zygote sandbox (it seems that the resolution is a bit faster)
     options.add_argument('--no-zygote')
     # attempt to fix Docker ARM32 build

--- a/src/utils.py
+++ b/src/utils.py
@@ -222,6 +222,20 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     if proxy_extension_dir is not None:
         shutil.rmtree(proxy_extension_dir)
 
+    # Strip ChromeDriver's `cdc_`/`$cdc`/`$webdriver` marker properties from every
+    # document before page scripts run. undetected_chromedriver renames them in the
+    # driver binary, but pointer-trust captchas (Filecrypt's m.js) scan for these
+    # names and flag the browser as automated if any survive; this is a cheap
+    # belt-and-suspenders that runs on every navigation.
+    try:
+        driver.execute_cdp_cmd('Page.addScriptToEvaluateOnNewDocument', {'source': (
+            "(function(){try{Object.getOwnPropertyNames(window).forEach(function(k){"
+            "if(/cdc_|\\$cdc|\\$chrome_asyncScriptInfo|\\$webdriver/.test(k)){"
+            "try{delete window[k];}catch(e){}}});}catch(e){}})();"
+        )})
+    except Exception as e:
+        logging.debug("Could not install cdc_ cleanup script: %s" % e)
+
     # selenium vanilla
     # options = webdriver.ChromeOptions()
     # options.add_argument('--no-sandbox')


### PR DESCRIPTION
## What

Adds an optional `executeJs` param to `request.get` / `request.post`, an optional `trustedClick` mode on top of it, and the Chromium launch/runtime settings these need to be useful. No behaviour change when the params are absent.

## Why

FlareSolverr today can only return HTML + cookies. A growing number of protected pages need a JavaScript step *after* the Cloudflare challenge — e.g. completing an in-page proof-of-work captcha, or reading state that only exists in the solved browser context. `flaresolverr-go` has `executeJs` but does not reliably bypass Cloudflare (FlareSolverr's core job), so it isn't a dependable alternative. This closes that gap without regressing Cloudflare bypass.

## Changes

1. **`executeJs` → `solution.executeJsResult`** — runs the snippet in the solved page via CDP `Runtime.evaluate` (`awaitPromise`), in the browser context FlareSolverr already established. May `return` a value or a `Promise`; result returned as a string. Bounded by `EXECUTE_JS_TIMEOUT` (default 20s).

2. **Launch with `--js-flags=--no-maglev`** — since ~Chrome 138, V8's Maglev JIT runs integer/typed-array-heavy Web Worker code ~40x slower (measured ~70k vs ~3.5M ops/s on a real PoW worker) and can miscompile it to an invalid result. Without this, a PoW worker driven via `executeJs` never finishes within `maxTimeout`. Only changes the JIT tier; ordinary solving is unaffected.

3. **`trustedClick` → trusted CDP pointer click** — some captchas reject JS-synthesised events (`isTrusted=false`). With `trustedClick: true`, `executeJs` runs as an "arm" script that returns `{"trustedClick":{"x","y"}}`; FlareSolverr dispatches a real trusted pointer click there via CDP `Input.dispatchMouseEvent` and awaits `window.__FRS_AWAIT`. Bounded by `TRUSTED_CLICK_TIMEOUT` (default 90s). Also foregrounds the page and enables focus emulation so in-page workers aren't background-throttled.

4. **Strip ChromeDriver automation markers** — a `Page.addScriptToEvaluateOnNewDocument` step removes `cdc_` / `$cdc` / `$webdriver` properties that pointer-trust captchas fingerprint on, as belt-and-suspenders over undetected_chromedriver. Exception-guarded; never affects startup.

## Testing

- `executeJs` returns synchronous values, awaited Promises, and Web Worker results.
- A real in-page PoW captcha solves in real time with `--no-maglev`; times out / returns an invalid nonce without it.
- A real pointer-trust PoW captcha solves end-to-end (~3s) with `trustedClick`; a synthetic `executeJs` click is rejected and re-served.
- No regression: a live Cloudflare-gated page still returns HTTP 200 with `cf_clearance` + `Challenge solved!`.
