### PR TITLE
Fix unexpected alert issue #1719 by accepting unhandled prompts

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -135,6 +135,7 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
 
     # undetected_chromedriver
     options = uc.ChromeOptions()
+    options.set_capability('unhandledPromptBehavior', 'accept')
     options.add_argument('--no-sandbox')
     options.add_argument('--window-size=1920,1080')
     options.add_argument('--disable-search-engine-choice-screen')


### PR DESCRIPTION
Fixes #1719.

Sets the W3C capability `unhandledPromptBehavior` to `'accept'` in the `undetected_chromedriver` options. This ensures that any unexpected JavaScript alerts (like the "Close dev tool & reload" prompt on `nepu.to`) are silently accepted, preventing the challenge solver from crashing via `UnexpectedAlertPresentException`.
