### PR TITLE
feat: add request.post_json command for same-origin JSON fetch via browser

### DIFF
--- a/src/dtos.py
+++ b/src/dtos.py
@@ -42,6 +42,7 @@ class V1RequestBase(object):
     # V1Request
     url: str = None
     postData: str = None
+    jsonBody: str = None
     returnOnlyCookies: bool = None
     returnScreenshot: bool = None
     download: bool = None   # deprecated v2.0.0, not used

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -4,7 +4,7 @@ import sys
 import time
 from datetime import timedelta
 from html import escape
-from urllib.parse import unquote, quote
+from urllib.parse import unquote, quote, urlparse
 
 from func_timeout import FunctionTimedOut, func_timeout
 from selenium.common import TimeoutException
@@ -141,6 +141,8 @@ def _controller_v1_handler(req: V1RequestBase) -> V1ResponseBase:
         res = _cmd_request_get(req)
     elif req.cmd == 'request.post':
         res = _cmd_request_post(req)
+    elif req.cmd == 'request.post_json':
+        res = _cmd_request_post_json(req)
     else:
         raise Exception(f"Request parameter 'cmd' = '{req.cmd}' is invalid.")
 
@@ -180,6 +182,76 @@ def _cmd_request_post(req: V1RequestBase) -> V1ResponseBase:
     res.status = challenge_res.status
     res.message = challenge_res.message
     res.solution = challenge_res.result
+    return res
+
+
+def _cmd_request_post_json(req: V1RequestBase) -> V1ResponseBase:
+    if req.url is None:
+        raise Exception("Request parameter 'url' is mandatory in 'request.post_json' command.")
+    if req.jsonBody is None:
+        raise Exception("Request parameter 'jsonBody' is mandatory in 'request.post_json' command.")
+    if not req.session:
+        raise Exception("Request parameter 'session' is mandatory in 'request.post_json' command.")
+
+    timeout = int(req.maxTimeout) / 1000
+
+    # Navigate to the origin first so Chrome solves the Cloudflare challenge.
+    parsed = urlparse(req.url)
+    origin_url = f"{parsed.scheme}://{parsed.netloc}"
+    origin_req = V1RequestBase({
+        "cmd": "request.get",
+        "url": origin_url,
+        "session": req.session,
+        "maxTimeout": req.maxTimeout,
+    })
+    _resolve_challenge(origin_req, 'GET')
+
+    ttl = timedelta(minutes=req.session_ttl_minutes) if req.session_ttl_minutes else None
+    session, _ = SESSIONS_STORAGE.get(req.session, ttl)
+    driver = session.driver
+
+    driver.set_script_timeout(timeout)
+
+    fetch_script = """
+        var done = arguments[arguments.length - 1];
+        fetch(arguments[0], {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: arguments[1],
+            credentials: 'include'
+        })
+        .then(function(r) {
+            return r.text().then(function(text) {
+                done(JSON.stringify({s: r.status, b: text}));
+            });
+        })
+        .catch(function(e) {
+            done(JSON.stringify({s: 0, b: e.toString()}));
+        });
+    """
+
+    try:
+        raw = func_timeout(
+            timeout,
+            driver.execute_async_script,
+            (fetch_script, req.url, req.jsonBody),
+        )
+    except FunctionTimedOut:
+        raise Exception(f'Error executing request.post_json. Timeout after {timeout} seconds.')
+    except Exception as e:
+        raise Exception(f'Error executing request.post_json: {str(e)}')
+
+    challenge_res = ChallengeResolutionResultT({})
+    challenge_res.url = req.url
+    challenge_res.status = 200
+    challenge_res.cookies = driver.get_cookies()
+    challenge_res.userAgent = utils.get_user_agent(driver)
+    challenge_res.response = raw
+
+    res = V1ResponseBase({})
+    res.status = STATUS_OK
+    res.message = "OK"
+    res.solution = challenge_res
     return res
 
 

--- a/src/test_sploitus.py
+++ b/src/test_sploitus.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Quick proof-of-concept: call sploitus via patched FlareSolverr."""
+
+import json
+import sys
+import time
+import urllib.request
+
+FLARESOLVERR_URL = "http://localhost:8191/v1"
+SPLOITUS_SEARCH_URL = "https://sploitus.com/search"
+SEARCH_QUERY = {"type": "exploits", "query": "log4j", "sort": "default", "title": False, "offset": 0}
+MAX_TIMEOUT = 90000
+
+
+def post(payload: dict) -> dict:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        FLARESOLVERR_URL,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def main():
+    print("[1] Creating FlareSolverr session...")
+    create_resp = post({"cmd": "sessions.create", "maxTimeout": MAX_TIMEOUT})
+    if create_resp.get("status") != "ok":
+        print("FAIL: sessions.create =>", create_resp)
+        sys.exit(1)
+    session_id = create_resp["session"]
+    print(f"    session_id = {session_id}")
+
+    try:
+        print("[2] Sending request.post_json to sploitus...")
+        t0 = time.time()
+        search_resp = post({
+            "cmd": "request.post_json",
+            "url": SPLOITUS_SEARCH_URL,
+            "jsonBody": json.dumps(SEARCH_QUERY),
+            "session": session_id,
+            "maxTimeout": MAX_TIMEOUT,
+        })
+        elapsed = time.time() - t0
+        print(f"    completed in {elapsed:.1f}s")
+
+        if search_resp.get("status") != "ok":
+            print("FAIL: request.post_json =>", json.dumps(search_resp, indent=2))
+            sys.exit(1)
+
+        raw = search_resp["solution"]["response"]
+        print(f"[3] Raw envelope from browser: {raw[:300]}")
+
+        envelope = json.loads(raw)
+        http_status = envelope["s"]
+        body = envelope["b"]
+        print(f"[4] HTTP status from fetch: {http_status}")
+
+        if http_status != 200:
+            print(f"FAIL: sploitus returned HTTP {http_status}")
+            print("Body:", body[:500])
+            sys.exit(1)
+
+        result = json.loads(body)
+        exploits = result.get("exploits", [])
+        total = result.get("search_total", "?")
+        print(f"[5] SUCCESS - total results: {total}, first page count: {len(exploits)}")
+        if exploits:
+            first = exploits[0]
+            print(f"    First exploit: {first.get('title', '?')} | score={first.get('score', '?')}")
+
+    finally:
+        print("[6] Destroying session...")
+        post({"cmd": "sessions.destroy", "session": session_id})
+        print("    done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a new `cmd` value `request.post_json` that sends a JSON POST request
from within the browser's page context using `fetch()`, after Cloudflare
challenge resolution.

## Why

Some endpoints (e.g. sploitus.com/search) require an interactive Cloudflare
Turnstile token and session cookies that are only present in a live, solved
browser session. A plain HTTP POST from the host cannot carry those credentials.
By running `fetch()` from inside Chrome after the challenge is solved, the
request is same-origin and all cookies and tokens are included automatically.

## Key changes

- `dtos.py`: added `jsonBody: str = None` field to `V1RequestBase`
- `flaresolverr_service.py`: added `request.post_json` dispatcher branch
- new `_cmd_request_post_json` handler:
  1. Navigates Chrome to the target origin via `_resolve_challenge` (solves CF)
  2. Retrieves the live driver from the session store
  3. Executes an async `fetch()` POST with `Content-Type: application/json` via `execute_async_script`
  4. Returns the raw `{s: <status>, b: <body>}` envelope as `solution.response`

The `session` parameter is mandatory - the caller must create a session first
and pass its ID, so the driver is preserved between the navigation and the fetch.

## Testing

Tested against `https://sploitus.com/search` (Cloudflare Bot Management +
interactive Turnstile). The command navigated to the origin, solved the
challenge, and returned HTTP 200 with valid JSON exploit results.
