### PR TITLE
Preserve Bottle 400 for malformed JSON

### DIFF
--- a/src/bottle_plugins/error_plugin.py
+++ b/src/bottle_plugins/error_plugin.py
@@ -1,4 +1,4 @@
-from bottle import response
+from bottle import HTTPResponse, response
 import logging
 
 
@@ -11,6 +11,9 @@ def error_plugin(callback):
     def wrapper(*args, **kwargs):
         try:
             actual_response = callback(*args, **kwargs)
+        except HTTPResponse:
+            # Bottle uses HTTPResponse exceptions for HTTP control flow.
+            raise
         except Exception as e:
             logging.error(str(e))
             actual_response = {

--- a/src/test_error_plugin.py
+++ b/src/test_error_plugin.py
@@ -1,0 +1,43 @@
+import unittest
+
+from bottle import Bottle, request
+from webtest import TestApp
+
+from bottle_plugins.error_plugin import error_plugin
+
+
+class TestErrorPlugin(unittest.TestCase):
+
+    def setUp(self):
+        app = Bottle()
+
+        @app.post('/json')
+        def parse_json():
+            return request.json
+
+        @app.get('/error')
+        def raise_error():
+            raise RuntimeError('unexpected failure')
+
+        app.install(error_plugin)
+        self.app = TestApp(app)
+
+    def test_preserves_bottle_http_error_status(self):
+        response = self.app.post(
+            '/json',
+            params='{',
+            content_type='application/json',
+            status=400
+        )
+
+        self.assertEqual(400, response.status_code)
+
+    def test_converts_unexpected_exception_to_500(self):
+        response = self.app.get('/error', status=500)
+
+        self.assertEqual(500, response.status_code)
+        self.assertEqual({'error': 'unexpected failure'}, response.json)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- preserve Bottle `HTTPResponse` exceptions in `error_plugin` instead of converting them to JSON 500 responses
- add focused regression coverage for malformed JSON staying HTTP 400
- keep ordinary unexpected exceptions mapped to the existing JSON 500 response

Closes #1748.

Credit to @potatosips for the detailed reproduction and suggested minimal fix in the issue thread.

## Tests

- `PYTHONPATH=src python -m unittest src/test_error_plugin.py`
- `python -m compileall -q src/bottle_plugins/error_plugin.py src/test_error_plugin.py`
- manual WebTest smoke: `/v1` malformed `{` returns `400 Bad Request` with `{"error": "Invalid JSON", "status_code": 400}` after installing `error_plugin`
