### PR TITLE
Fix request handling, session races, and safe defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ This works like `request.get`, with the addition of the postData parameter. Note
 | DISABLE_MEDIA      | false                  | To disable loading images, CSS, and other media in the web browser to save network bandwidth.                                            |
 | TEST_URL           | https://www.google.com | FlareSolverr makes a request on start to make sure the web browser is working. You can change that URL if it is blocked in your country. |
 | PORT               | 8191                   | Listening port. You don't need to change this if you are running on Docker.                                                              |
+| PORT_BIND          | 127.0.0.1              | Docker Compose host interface for `PORT`. Set this to `0.0.0.0` only when you deliberately need remote access. |
 | HOST               | 0.0.0.0                | Listening interface. You don't need to change this if you are running on Docker.                                                         |
 | PROMETHEUS_ENABLED | false                  | Enable Prometheus exporter. See the Prometheus section below.                                                                            |
 | PROMETHEUS_PORT    | 8192                   | Listening port for Prometheus exporter. See the Prometheus section below.                                                                |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - CAPTCHA_SOLVER=${CAPTCHA_SOLVER:-none}
       - TZ=Europe/London
     ports:
-      - "${PORT:-8191}:8191"
+      - "${PORT_BIND:-127.0.0.1}:${PORT:-8191}:8191"
     volumes:
       - /var/lib/flaresolver:/config
     restart: unless-stopped

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -4,7 +4,7 @@ import sys
 import time
 from datetime import timedelta
 from html import escape
-from urllib.parse import unquote, quote
+from urllib.parse import parse_qsl, quote
 
 from func_timeout import FunctionTimedOut, func_timeout
 from selenium.common import TimeoutException
@@ -97,7 +97,7 @@ def health_endpoint() -> HealthResponse:
 
 def controller_v1_endpoint(req: V1RequestBase) -> V1ResponseBase:
     start_ts = int(time.time() * 1000)
-    logging.info(f"Incoming request => POST /v1 body: {utils.object_to_dict(req)}")
+    logging.info(f"Incoming request => POST /v1 body: {utils.redact_sensitive_data(utils.object_to_dict(req))}")
     res: V1ResponseBase
     try:
         res = _controller_v1_handler(req)
@@ -111,7 +111,7 @@ def controller_v1_endpoint(req: V1RequestBase) -> V1ResponseBase:
     res.startTimestamp = start_ts
     res.endTimestamp = int(time.time() * 1000)
     res.version = utils.get_flaresolverr_version()
-    logging.debug(f"Response => POST /v1 body: {utils.object_to_dict(res)}")
+    logging.debug(f"Response => POST /v1 body: {utils.redact_sensitive_data(utils.object_to_dict(res))}")
     logging.info(f"Response in {(res.endTimestamp - res.startTimestamp) / 1000} s")
     return res
 
@@ -168,6 +168,8 @@ def _cmd_request_get(req: V1RequestBase) -> V1ResponseBase:
 
 def _cmd_request_post(req: V1RequestBase) -> V1ResponseBase:
     # do some validations
+    if req.url is None:
+        raise Exception("Request parameter 'url' is mandatory in 'request.post' command.")
     if req.postData is None:
         raise Exception("Request parameter 'postData' is mandatory in 'request.post' command.")
     if req.returnRawHtml is not None:
@@ -487,26 +489,12 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
 
 
 def _post_request(req: V1RequestBase, driver: WebDriver):
-    post_form = f'<form id="hackForm" action="{req.url}" method="POST">'
-    query_string = req.postData if req.postData and req.postData[0] != '?' else req.postData[1:] if req.postData else ''
-    pairs = query_string.split('&')
-    for pair in pairs:
-        parts = pair.split('=', 1)
-        # noinspection PyBroadException
-        try:
-            name = unquote(parts[0])
-        except Exception:
-            name = parts[0]
+    post_form = f'<form id="hackForm" action="{escape(req.url, quote=True)}" method="POST">'
+    query_string = req.postData[1:] if req.postData.startswith('?') else req.postData
+    for name, value in parse_qsl(query_string, keep_blank_values=True):
         if name == 'submit':
             continue
-        # noinspection PyBroadException
-        try:
-            value = unquote(parts[1]) if len(parts) > 1 else ''
-        except Exception:
-            value = parts[1] if len(parts) > 1 else ''
-        # Protection of " character, for syntax
-        value=value.replace('"','&quot;')
-        post_form += f'<input type="text" name="{escape(quote(name))}" value="{escape(quote(value))}"><br>'
+        post_form += f'<input type="text" name="{escape(name, quote=True)}" value="{escape(value, quote=True)}"><br>'
     post_form += '</form>'
     html_content = f"""
         <!DOCTYPE html>
@@ -516,4 +504,4 @@ def _post_request(req: V1RequestBase, driver: WebDriver):
             <script>document.getElementById('hackForm').submit();</script>
         </body>
         </html>"""
-    driver.get("data:text/html;charset=utf-8,{html_content}".format(html_content=html_content))
+    driver.get("data:text/html;charset=utf-8," + quote(html_content, safe=""))

--- a/src/sessions.py
+++ b/src/sessions.py
@@ -1,4 +1,5 @@
 import logging
+from threading import RLock
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Optional, Tuple
@@ -24,6 +25,7 @@ class SessionsStorage:
 
     def __init__(self):
         self.sessions = {}
+        self._lock = RLock()
 
     def create(self, session_id: Optional[str] = None, proxy: Optional[dict] = None,
                force_new: Optional[bool] = False) -> Tuple[Session, bool]:
@@ -39,22 +41,24 @@ class SessionsStorage:
         """
         session_id = session_id or str(uuid1())
 
-        if force_new:
-            self.destroy(session_id)
+        with self._lock:
+            if force_new:
+                self.destroy(session_id)
 
-        if self.exists(session_id):
-            return self.sessions[session_id], False
+            if self.exists(session_id):
+                return self.sessions[session_id], False
 
-        driver = utils.get_webdriver(proxy)
-        created_at = datetime.now()
-        session = Session(session_id, driver, created_at)
+            driver = utils.get_webdriver(proxy)
+            created_at = datetime.now()
+            session = Session(session_id, driver, created_at)
 
-        self.sessions[session_id] = session
+            self.sessions[session_id] = session
 
-        return session, True
+            return session, True
 
     def exists(self, session_id: str) -> bool:
-        return session_id in self.sessions
+        with self._lock:
+            return session_id in self.sessions
 
     def destroy(self, session_id: str) -> bool:
         """destroy closes the driver instance and removes session from the storage.
@@ -62,23 +66,26 @@ class SessionsStorage:
         The function returns True if session was found and destroyed,
         and False if session_id wasn't found.
         """
-        if not self.exists(session_id):
-            return False
+        with self._lock:
+            if not self.exists(session_id):
+                return False
 
-        session = self.sessions.pop(session_id)
-        if utils.PLATFORM_VERSION == "nt":
-            session.driver.close()
-        session.driver.quit()
-        return True
+            session = self.sessions.pop(session_id)
+            if utils.PLATFORM_VERSION == "nt":
+                session.driver.close()
+            session.driver.quit()
+            return True
 
     def get(self, session_id: str, ttl: Optional[timedelta] = None) -> Tuple[Session, bool]:
-        session, fresh = self.create(session_id)
+        with self._lock:
+            session, fresh = self.create(session_id)
 
-        if ttl is not None and not fresh and session.lifetime() > ttl:
-            logging.debug(f'session\'s lifetime has expired, so the session is recreated (session_id={session_id})')
-            session, fresh = self.create(session_id, force_new=True)
+            if ttl is not None and not fresh and session.lifetime() > ttl:
+                logging.debug(f'session\'s lifetime has expired, so the session is recreated (session_id={session_id})')
+                session, fresh = self.create(session_id, force_new=True)
 
-        return session, fresh
+            return session, fresh
 
     def session_ids(self) -> list[str]:
-        return list(self.sessions.keys())
+        with self._lock:
+            return list(self.sessions.keys())

--- a/src/test_regressions.py
+++ b/src/test_regressions.py
@@ -1,0 +1,135 @@
+import json
+import shutil
+import threading
+import time
+import unittest
+from html.parser import HTMLParser
+from unittest.mock import patch
+from urllib.parse import unquote
+
+import flaresolverr_service
+import utils
+from dtos import V1RequestBase
+from sessions import SessionsStorage
+
+
+class FormParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.action = None
+        self.inputs = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == 'form':
+            self.action = attrs['action']
+        if tag == 'input':
+            self.inputs.append((attrs['name'], attrs['value']))
+
+
+class FakeDriver:
+    def __init__(self):
+        self.url = None
+
+    def get(self, url):
+        self.url = url
+
+
+class TestPostRequestEncoding(unittest.TestCase):
+    def test_post_data_is_decoded_once_before_browser_form_submission(self):
+        driver = FakeDriver()
+        request = V1RequestBase({
+            'url': 'https://example.test/form?source=FlareSolverr',
+            'postData': 'space=hello+world&encoded=one%26two&empty=&submit=ignored',
+        })
+
+        flaresolverr_service._post_request(request, driver)
+
+        self.assertTrue(driver.url.startswith('data:text/html;charset=utf-8,'))
+        parser = FormParser()
+        parser.feed(unquote(driver.url.split(',', 1)[1]))
+        self.assertEqual('https://example.test/form?source=FlareSolverr', parser.action)
+        self.assertEqual(
+            [('space', 'hello world'), ('encoded', 'one&two'), ('empty', '')],
+            parser.inputs,
+        )
+
+    def test_request_post_requires_a_url_before_creating_a_browser(self):
+        request = V1RequestBase({'cmd': 'request.post', 'postData': 'one=two'})
+
+        with patch('flaresolverr_service._resolve_challenge') as resolve_challenge:
+            with self.assertRaisesRegex(Exception, "Request parameter 'url' is mandatory"):
+                flaresolverr_service._cmd_request_post(request)
+            resolve_challenge.assert_not_called()
+
+
+class TestProxyExtension(unittest.TestCase):
+    def test_credentials_with_quotes_create_valid_json_in_the_extension(self):
+        username = 'user"; globalThis.injected = true; //'
+        password = 'pass"; globalThis.injected = true; //'
+        directory = utils.create_proxy_extension({
+            'url': 'http://127.0.0.1:8080',
+            'username': username,
+            'password': password,
+        })
+        self.addCleanup(shutil.rmtree, directory)
+
+        with open(f'{directory}/background.js', encoding='utf-8') as extension_file:
+            extension = extension_file.read()
+
+        self.assertIn(json.dumps({'username': username, 'password': password}), extension)
+        self.assertNotIn(f'username: "{username}"', extension)
+
+
+class TestSessionStorageConcurrency(unittest.TestCase):
+    def test_simultaneous_create_with_one_id_starts_only_one_driver(self):
+        storage = SessionsStorage()
+        start = threading.Barrier(3)
+        drivers = []
+
+        def create_driver(_proxy):
+            time.sleep(0.1)
+            driver = object()
+            drivers.append(driver)
+            return driver
+
+        def create_session():
+            start.wait()
+            return storage.create('same-session')
+
+        with patch('sessions.utils.get_webdriver', side_effect=create_driver):
+            first = threading.Thread(target=create_session)
+            second = threading.Thread(target=create_session)
+            first.start()
+            second.start()
+            start.wait()
+            first.join()
+            second.join()
+
+        self.assertEqual(1, len(drivers))
+        self.assertEqual(['same-session'], storage.session_ids())
+
+
+class TestSensitiveLogging(unittest.TestCase):
+    def test_sensitive_api_data_is_removed_before_logging(self):
+        data = {
+            'proxy': {'url': 'http://proxy.test', 'password': 'proxy-secret'},
+            'cookies': [{'name': 'session', 'value': 'cookie-secret'}],
+            'headers': {'Authorization': 'header-secret'},
+            'postData': 'password=form-secret',
+            'solution': {'response': 'response-secret', 'screenshot': 'image-secret'},
+        }
+
+        safe_data = utils.redact_sensitive_data(data)
+
+        self.assertNotIn('proxy-secret', repr(safe_data))
+        self.assertNotIn('cookie-secret', repr(safe_data))
+        self.assertNotIn('header-secret', repr(safe_data))
+        self.assertNotIn('form-secret', repr(safe_data))
+        self.assertNotIn('response-secret', repr(safe_data))
+        self.assertNotIn('image-secret', repr(safe_data))
+        self.assertEqual('[REDACTED]', safe_data['proxy'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,6 +19,10 @@ USER_AGENT = None
 XVFB_DISPLAY = None
 PATCHED_DRIVER_PATH = None
 
+SENSITIVE_LOG_FIELDS = frozenset({
+    'cookies', 'headers', 'password', 'postdata', 'proxy', 'response', 'screenshot', 'turnstile_token'
+})
+
 
 def get_config_log_html() -> bool:
     return os.environ.get('LOG_HTML', 'false').lower() == 'true'
@@ -81,27 +85,26 @@ def create_proxy_extension(proxy: dict) -> str:
     }
     """
 
-    background_js = """
-    var config = {
-        mode: "fixed_servers",
-        rules: {
-            singleProxy: {
-                scheme: "%s",
-                host: "%s",
-                port: %d
+    config = {
+        "mode": "fixed_servers",
+        "rules": {
+            "singleProxy": {
+                "scheme": scheme,
+                "host": host,
+                "port": port,
             },
-            bypassList: ["localhost"]
-        }
-    };
+            "bypassList": ["localhost"],
+        },
+    }
+    credentials = {"username": username, "password": password}
+    background_js = """
+    var config = %s;
 
     chrome.proxy.settings.set({value: config, scope: "regular"}, function() {});
 
     function callbackFn(details) {
         return {
-            authCredentials: {
-                username: "%s",
-                password: "%s"
-            }
+            authCredentials: %s
         };
     }
 
@@ -110,13 +113,7 @@ def create_proxy_extension(proxy: dict) -> str:
         { urls: ["<all_urls>"] },
         ['blocking']
     );
-    """ % (
-        scheme,
-        host,
-        port,
-        username,
-        password
-    )
+    """ % (json.dumps(config), json.dumps(credentials))
 
     proxy_extension_dir = tempfile.mkdtemp()
 
@@ -347,3 +344,15 @@ def object_to_dict(_object):
     json_dict = json.loads(json.dumps(_object, default=lambda o: o.__dict__))
     # remove hidden fields
     return {k: v for k, v in json_dict.items() if not k.startswith('__')}
+
+
+def redact_sensitive_data(data):
+    """Return a logging-safe copy of API data without request or session secrets."""
+    if isinstance(data, dict):
+        return {
+            key: '[REDACTED]' if key.lower() in SENSITIVE_LOG_FIELDS else redact_sensitive_data(value)
+            for key, value in data.items()
+        }
+    if isinstance(data, list):
+        return [redact_sensitive_data(value) for value in data]
+    return data


### PR DESCRIPTION
## Summary

Fix five independently reproducible issues found against upstream master (0f05ed8fc974b215c36892b5a30122e27fe3c671):

- Parse URL-encoded request.post data once, preserve blank fields, and validate url.
- Serialize proxy extension configuration and credentials safely.
- Synchronize session storage to prevent duplicate browser creation.
- Redact sensitive API-log values.
- Bind Compose ports to loopback by default, with a PORT_BIND override.

## Validation

- python -m unittest discover -s src -p test_regressions.py -v
- python -m compileall src
- git diff --check
- Patch applies cleanly to a fresh upstream checkout.

- Fixes #1750
- Fixes #1751
- Fixes #1752
- Fixes #1753
- Fixes #1754