### PR TITLE
feat: add pluggable captcha solvers with a 2captcha adapter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@
 .idea/
 html_samples/
 resources/
+.venv/
+**/__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Add pluggable captcha solvers with a 2captcha adapter (`CAPTCHA_SOLVER=2captcha`, `TWOCAPTCHA_API_KEY`). Automatically detects and solves Cloudflare Turnstile, hCaptcha and reCAPTCHA v2/v3.
+
 ## v3.5.0 (2026/05/26)
 * Add formatting to log file
 * Resolve turnstile captcha. Thanks @denis-svg

--- a/README.md
+++ b/README.md
@@ -287,7 +287,8 @@ This works like `request.get`, with the addition of the postData parameter. Note
 | PROXY_URL          | none                   | URL for proxy. Will be overwritten by `request` or `sessions` proxy, if used. Example: `http://127.0.0.1:8080`.                          |
 | PROXY_USERNAME     | none                   | Username for proxy. Will be overwritten by `request` or `sessions` proxy, if used. Example: `testuser`.                                  |
 | PROXY_PASSWORD     | none                   | Password for proxy. Will be overwritten by `request` or `sessions` proxy, if used. Example: `testpass`.                                  |
-| CAPTCHA_SOLVER     | none                   | Captcha solving method. It is used when a captcha is encountered. See the Captcha Solvers section.                                       |
+| CAPTCHA_SOLVER     | none                   | Captcha solving method. It is used when a captcha is encountered. Set to `2captcha` to use the 2captcha adapter. See the Captcha Solvers section. |
+| TWOCAPTCHA_API_KEY | none                   | API key for [2captcha](https://2captcha.com). Required when `CAPTCHA_SOLVER=2captcha`.                                                    |
 | TZ                 | UTC                    | Timezone used in the logs and the web browser. Example: `TZ=Europe/London`.                                                              |
 | LANG               | none                   | Language used in the web browser. Example: `LANG=en_GB`.                                                                                 |
 | HEADLESS           | true                   | Only for debugging. To run the web browser in headless mode or visible.                                                                  |
@@ -333,15 +334,49 @@ flaresolverr_request_duration_created{domain="nowsecure.nl"} 1.6901416571570296e
 
 ## Captcha Solvers
 
-> **Warning**
-> At this time none of the captcha solvers work. You can check the status in the open issues. Any help is welcome.
+Sometimes CloudFlare (and other sites) not only give mathematical computations and browser tests, they also require the
+user to solve a captcha (Cloudflare **Turnstile**, **hCaptcha** or Google **reCAPTCHA**). FlareSolverr can be configured
+to solve these automatically through a third-party captcha-solving service.
 
-Sometimes CloudFlare not only gives mathematical computations and browser tests, sometimes they also require the user to
-solve a captcha.
-If this is the case, FlareSolverr will return the error `Captcha detected but no automatic solver is configured.`
+A captcha solver is an *adapter* file inside the `src/captcha` directory. The active adapter is selected with the
+`CAPTCHA_SOLVER` environment variable, whose value is the adapter file name without the `.py` extension. When it is unset
+or set to `none`, no captcha solving is attempted (default behaviour).
 
-FlareSolverr can be customized to solve the CAPTCHA automatically by setting the environment variable `CAPTCHA_SOLVER`
-to the file name of one of the adapters inside the `/captcha` directory.
+### 2captcha
+
+[2captcha](https://2captcha.com) is a paid captcha-solving service. To enable it:
+
+```shell
+CAPTCHA_SOLVER=2captcha
+TWOCAPTCHA_API_KEY=<your 2captcha api key>
+```
+
+Supported captcha types: Cloudflare Turnstile, hCaptcha and reCAPTCHA v2/v3.
+
+Optional environment variables for fine-tuning the 2captcha client:
+
+| Name                        | Default        | Notes                                                                 |
+| --------------------------- | -------------- | --------------------------------------------------------------------- |
+| TWOCAPTCHA_SERVER           | `2captcha.com` | API host. Use `rucaptcha.com` for RuCaptcha.                          |
+| TWOCAPTCHA_SOFT_ID          | none           | Software id sent to the API.                                          |
+| TWOCAPTCHA_DEFAULT_TIMEOUT  | `120`          | Seconds to wait for a solution before giving up.                      |
+| TWOCAPTCHA_POLLING_INTERVAL | `10`           | Seconds between result polls.                                         |
+
+How it works: when a request hits a page with a supported captcha, FlareSolverr detects it, extracts the site key, sends
+it to 2captcha, waits for the token and injects it back into the page (triggering the widget callback). The solved page
+(cookies and HTML) is then returned as usual. For a solved Turnstile the token is also available in the response under
+`solution.turnstile_token`, and every automatically solved captcha is reported under `solution.captcha`
+(`{"type": "...", "token": "..."}`).
+
+> **Note**
+> Solving a captcha through an external service can take from a few seconds up to a minute. Increase the request
+> `maxTimeout` (e.g. `120000`) so the solver has enough time to return a token.
+
+### Writing your own adapter
+
+Create `src/captcha/<name>.py` exposing a `get_solver()` function that returns an object implementing the
+`CaptchaSolver` interface (`solve_turnstile`, `solve_hcaptcha`, `solve_recaptcha`) defined in `src/captcha/__init__.py`,
+then set `CAPTCHA_SOLVER=<name>`.
 
 ## Related projects
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - LOG_FILE=${LOG_FILE:-none}
       - LOG_HTML=${LOG_HTML:-false}
       - CAPTCHA_SOLVER=${CAPTCHA_SOLVER:-none}
+      # Required when CAPTCHA_SOLVER=2captcha
+      - TWOCAPTCHA_API_KEY=${TWOCAPTCHA_API_KEY:-}
       - TZ=Europe/London
     ports:
       - "${PORT:-8191}:8191"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ waitress==3.0.2
 selenium==4.39.0
 func-timeout==4.3.5
 prometheus-client==0.23.1
+# Captcha solver adapters (CAPTCHA_SOLVER=2captcha)
+2captcha-python==2.1.0
 # Required by undetected_chromedriver
 requests==2.32.5
 certifi==2025.11.12

--- a/src/captcha/2captcha.py
+++ b/src/captcha/2captcha.py
@@ -1,0 +1,83 @@
+"""2captcha (https://2captcha.com) adapter for FlareSolverr.
+
+Enable it with::
+
+    CAPTCHA_SOLVER=2captcha
+    TWOCAPTCHA_API_KEY=<your api key>
+
+Optional environment variables:
+
+    TWOCAPTCHA_SERVER            API host, defaults to ``2captcha.com``
+                                 (use ``rucaptcha.com`` for RuCaptcha).
+    TWOCAPTCHA_SOFT_ID           Software id sent to the API.
+    TWOCAPTCHA_DEFAULT_TIMEOUT   Seconds to wait for a solution (default 120).
+    TWOCAPTCHA_POLLING_INTERVAL  Seconds between result polls (default 10).
+
+This adapter is a thin wrapper around the official ``2captcha-python``
+library, mapping FlareSolverr's captcha types to the corresponding 2captcha
+methods and returning the solution token.
+"""
+import logging
+import os
+
+from twocaptcha import TwoCaptcha
+
+from captcha import CaptchaSolver
+
+
+class TwoCaptchaSolver(CaptchaSolver):
+    def __init__(self, api_key: str, **client_opts):
+        self._client = TwoCaptcha(api_key, **client_opts)
+
+    def solve_turnstile(self, *, url, sitekey, action=None, data=None,
+                        pagedata=None, useragent=None):
+        kwargs = {}
+        if action:
+            kwargs["action"] = action
+        if data:
+            kwargs["data"] = data
+        if pagedata:
+            kwargs["pagedata"] = pagedata
+        if useragent:
+            kwargs["useragent"] = useragent
+        logging.debug("Submitting Turnstile captcha to 2captcha (sitekey=%s)", sitekey)
+        result = self._client.turnstile(sitekey=sitekey, url=url, **kwargs)
+        return result["code"]
+
+    def solve_hcaptcha(self, *, url, sitekey):
+        logging.debug("Submitting hCaptcha to 2captcha (sitekey=%s)", sitekey)
+        result = self._client.hcaptcha(sitekey=sitekey, url=url)
+        return result["code"]
+
+    def solve_recaptcha(self, *, url, sitekey, version="v2", action=None):
+        kwargs = {"version": version}
+        if action:
+            kwargs["action"] = action
+        logging.debug("Submitting reCAPTCHA %s to 2captcha (sitekey=%s)", version, sitekey)
+        result = self._client.recaptcha(sitekey=sitekey, url=url, **kwargs)
+        return result["code"]
+
+
+def _int_env(name):
+    value = os.environ.get(name)
+    return int(value) if value else None
+
+
+def get_solver() -> TwoCaptchaSolver:
+    api_key = os.environ.get("TWOCAPTCHA_API_KEY") or os.environ.get("CAPTCHA_SOLVER_API_KEY")
+    if not api_key:
+        raise Exception("The 2captcha solver requires the 'TWOCAPTCHA_API_KEY' "
+                        "environment variable to be set.")
+
+    client_opts = {}
+    server = os.environ.get("TWOCAPTCHA_SERVER")
+    if server:
+        client_opts["server"] = server
+    for env_name, opt_name in (("TWOCAPTCHA_SOFT_ID", "softId"),
+                               ("TWOCAPTCHA_DEFAULT_TIMEOUT", "defaultTimeout"),
+                               ("TWOCAPTCHA_POLLING_INTERVAL", "pollingInterval")):
+        value = _int_env(env_name)
+        if value is not None:
+            client_opts[opt_name] = value
+
+    return TwoCaptchaSolver(api_key, **client_opts)

--- a/src/captcha/__init__.py
+++ b/src/captcha/__init__.py
@@ -1,0 +1,234 @@
+"""Pluggable captcha-solver support for FlareSolverr.
+
+A *captcha solver* is an adapter module placed inside this package (for
+example :mod:`captcha.2captcha`). The active adapter is selected with the
+``CAPTCHA_SOLVER`` environment variable, whose value is the adapter file name
+without the ``.py`` extension. When the variable is unset or set to ``none``
+no captcha solving is attempted and FlareSolverr keeps its previous behaviour.
+
+Each adapter module must expose a ``get_solver()`` function returning an object
+that implements the :class:`CaptchaSolver` protocol.
+
+This module also contains the browser-agnostic *detection* logic
+(:func:`detect_captcha`) and the JavaScript snippets used to read the captcha
+parameters from the page and to inject the solved token back into it. Keeping
+the detection logic pure (it operates on a plain ``dict`` of DOM facts) makes it
+straightforward to unit-test without a real browser.
+"""
+import importlib.util
+import logging
+import os
+import re
+from typing import Optional
+
+# Captcha types understood by the solvers / detection logic.
+TURNSTILE = "turnstile"
+HCAPTCHA = "hcaptcha"
+RECAPTCHA = "recaptcha"
+
+# Cloudflare Turnstile site keys look like ``0x4AAAAAAA...``.
+_TURNSTILE_SITEKEY_RE = re.compile(r"0x[0-9A-Za-z_-]{20,}")
+
+_SOLVER_CACHE: dict = {}
+
+
+class CaptchaSolver:
+    """Interface every captcha-solver adapter must implement.
+
+    Adapters may subclass this or simply provide an object with the same
+    methods (duck typing). Every ``solve_*`` method must return the solution
+    token as a string, or raise an exception when the captcha cannot be solved.
+    """
+
+    def solve_turnstile(self, *, url: str, sitekey: str, action: Optional[str] = None,
+                        data: Optional[str] = None, pagedata: Optional[str] = None,
+                        useragent: Optional[str] = None) -> str:
+        raise NotImplementedError
+
+    def solve_hcaptcha(self, *, url: str, sitekey: str) -> str:
+        raise NotImplementedError
+
+    def solve_recaptcha(self, *, url: str, sitekey: str, version: str = "v2",
+                        action: Optional[str] = None) -> str:
+        raise NotImplementedError
+
+
+def get_config_captcha_solver() -> Optional[str]:
+    """Return the configured captcha solver adapter name, or ``None``."""
+    name = os.environ.get("CAPTCHA_SOLVER", "none")
+    if not name or name.strip().lower() == "none":
+        return None
+    return name.strip()
+
+
+def get_solver() -> Optional[CaptchaSolver]:
+    """Load (and cache) the captcha solver selected by ``CAPTCHA_SOLVER``.
+
+    Returns ``None`` when no solver is configured. Raises an exception when a
+    solver is configured but cannot be loaded, so the misconfiguration is
+    surfaced to the user instead of being silently ignored.
+    """
+    name = get_config_captcha_solver()
+    if name is None:
+        return None
+
+    # only allow a plain file name, never a path (avoid loading arbitrary files)
+    safe_name = os.path.basename(name)
+    if safe_name in _SOLVER_CACHE:
+        return _SOLVER_CACHE[safe_name]
+
+    adapter_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), f"{safe_name}.py")
+    if not os.path.isfile(adapter_path):
+        raise Exception(f"Captcha solver '{name}' not found. "
+                        f"Expected an adapter file at '{adapter_path}'.")
+
+    # load by file location so adapter names that are not valid Python
+    # identifiers (e.g. '2captcha') can still be used.
+    spec = importlib.util.spec_from_file_location(f"captcha._adapter_{safe_name}", adapter_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    if not hasattr(module, "get_solver"):
+        raise Exception(f"Captcha solver '{name}' must expose a 'get_solver()' function.")
+
+    solver = module.get_solver()
+    _SOLVER_CACHE[safe_name] = solver
+    logging.info(f"Captcha solver '{name}' loaded.")
+    return solver
+
+
+# JavaScript executed in the page to collect everything needed to identify a
+# captcha and extract its site key. It returns a plain JSON-serialisable object
+# consumed by :func:`detect_captcha`.
+CAPTCHA_DETECT_JS = r"""
+const attr = (el, name) => (el && el.getAttribute(name)) || null;
+const collect = (selector, extra) => Array.from(document.querySelectorAll(selector)).map(el => {
+    const out = { sitekey: attr(el, 'data-sitekey') };
+    (extra || []).forEach(a => { out[a.replace('data-', '')] = attr(el, a); });
+    return out;
+});
+const iframeSrcs = Array.from(document.querySelectorAll('iframe')).map(f => f.src).filter(Boolean);
+return {
+    turnstileWidgets: collect('.cf-turnstile', ['data-action', 'data-cdata']),
+    hasTurnstileResponse: !!document.querySelector('[name="cf-turnstile-response"]'),
+    hcaptchaWidgets: collect('.h-captcha'),
+    hasHcaptchaResponse: !!document.querySelector('[name="h-captcha-response"]'),
+    recaptchaWidgets: collect('.g-recaptcha', ['data-action', 'data-size']),
+    hasRecaptchaResponse: !!document.querySelector('#g-recaptcha-response, [name="g-recaptcha-response"]'),
+    iframeSrcs: iframeSrcs
+};
+"""
+
+# JavaScript that injects a solved token back into the page and triggers the
+# widget callback (if any). Executed with the token as the single argument.
+CAPTCHA_INJECT_JS = {
+    TURNSTILE: r"""
+const token = arguments[0];
+document.querySelectorAll('[name="cf-turnstile-response"], #cf-turnstile-response, #cf-chl-widget-response')
+    .forEach(el => { el.value = token; });
+try {
+    const w = document.querySelector('.cf-turnstile');
+    const cb = w && w.getAttribute('data-callback');
+    if (cb && typeof window[cb] === 'function') window[cb](token);
+} catch (e) {}
+""",
+    HCAPTCHA: r"""
+const token = arguments[0];
+document.querySelectorAll('[name="h-captcha-response"], [name="g-recaptcha-response"], textarea#h-captcha-response, textarea#g-recaptcha-response')
+    .forEach(el => { el.value = token; el.innerHTML = token; });
+try {
+    const w = document.querySelector('.h-captcha');
+    const cb = w && w.getAttribute('data-callback');
+    if (cb && typeof window[cb] === 'function') window[cb](token);
+} catch (e) {}
+""",
+    RECAPTCHA: r"""
+const token = arguments[0];
+document.querySelectorAll('#g-recaptcha-response, [name="g-recaptcha-response"]')
+    .forEach(el => { el.style.display = 'block'; el.value = token; el.innerHTML = token; });
+try {
+    const w = document.querySelector('.g-recaptcha');
+    const cb = w && w.getAttribute('data-callback');
+    if (cb && typeof window[cb] === 'function') { window[cb](token); }
+    else if (window.___grecaptcha_cfg && window.___grecaptcha_cfg.clients) {
+        const clients = window.___grecaptcha_cfg.clients;
+        Object.values(clients).forEach(client => {
+            Object.values(client).forEach(obj => {
+                if (obj && typeof obj === 'object') {
+                    Object.values(obj).forEach(inner => {
+                        if (inner && typeof inner === 'object' && typeof inner.callback === 'function') {
+                            try { inner.callback(token); } catch (e) {}
+                        }
+                    });
+                }
+            });
+        });
+    }
+} catch (e) {}
+""",
+}
+
+
+def _sitekey_from_iframes(iframe_srcs: list, needles: list, param: Optional[str] = None,
+                          regex: Optional[re.Pattern] = None) -> Optional[str]:
+    """Best-effort extraction of a site key from captcha iframe URLs."""
+    for src in iframe_srcs or []:
+        if not any(needle in src for needle in needles):
+            continue
+        if param:
+            match = re.search(rf"[?&]{param}=([^&]+)", src)
+            if match:
+                return match.group(1)
+        if regex:
+            match = regex.search(src)
+            if match:
+                return match.group(0)
+    return None
+
+
+def detect_captcha(facts: dict, page_url: Optional[str] = None) -> Optional[dict]:
+    """Decide which captcha (if any) is present from a dict of DOM facts.
+
+    ``facts`` is the object returned by :data:`CAPTCHA_DETECT_JS`. Returns a
+    dict ``{type, sitekey, action, data, version}`` describing the captcha to
+    solve, or ``None`` when no supported captcha with a usable site key is
+    found. Turnstile is preferred over hCaptcha over reCAPTCHA when several are
+    present, matching the Cloudflare-centric use case of FlareSolverr.
+    """
+    if not facts:
+        return None
+    iframe_srcs = facts.get("iframeSrcs") or []
+
+    # -- Cloudflare Turnstile ------------------------------------------------
+    for widget in facts.get("turnstileWidgets") or []:
+        if widget.get("sitekey"):
+            return {"type": TURNSTILE, "sitekey": widget["sitekey"],
+                    "action": widget.get("action"), "data": widget.get("cdata")}
+    if facts.get("hasTurnstileResponse"):
+        sitekey = _sitekey_from_iframes(
+            iframe_srcs, ["challenges.cloudflare.com"], regex=_TURNSTILE_SITEKEY_RE)
+        if sitekey:
+            return {"type": TURNSTILE, "sitekey": sitekey, "action": None, "data": None}
+
+    # -- hCaptcha ------------------------------------------------------------
+    for widget in facts.get("hcaptchaWidgets") or []:
+        if widget.get("sitekey"):
+            return {"type": HCAPTCHA, "sitekey": widget["sitekey"]}
+    if facts.get("hasHcaptchaResponse") or any("hcaptcha.com" in s for s in iframe_srcs):
+        sitekey = _sitekey_from_iframes(iframe_srcs, ["hcaptcha.com"], param="sitekey")
+        if sitekey:
+            return {"type": HCAPTCHA, "sitekey": sitekey}
+
+    # -- Google reCAPTCHA ----------------------------------------------------
+    for widget in facts.get("recaptchaWidgets") or []:
+        if widget.get("sitekey"):
+            version = "v3" if widget.get("action") else "v2"
+            return {"type": RECAPTCHA, "sitekey": widget["sitekey"],
+                    "action": widget.get("action"), "version": version}
+    if facts.get("hasRecaptchaResponse") or any("recaptcha" in s for s in iframe_srcs):
+        sitekey = _sitekey_from_iframes(
+            iframe_srcs, ["google.com/recaptcha", "recaptcha.net"], param="k")
+        if sitekey:
+            return {"type": RECAPTCHA, "sitekey": sitekey, "action": None, "version": "v2"}
+
+    return None

--- a/src/dtos.py
+++ b/src/dtos.py
@@ -12,6 +12,9 @@ class ChallengeResolutionResultT:
     userAgent: str = None
     screenshot: str | None = None
     turnstile_token: str = None
+    # populated when a captcha was solved automatically by a configured solver:
+    # {"type": "turnstile"|"hcaptcha"|"recaptcha", "token": "<solution>"}
+    captcha: dict = None
 
     def __init__(self, _dict):
         self.__dict__.update(_dict)

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -16,6 +16,7 @@ from selenium.webdriver.support.expected_conditions import (
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support.wait import WebDriverWait
 
+import captcha
 import utils
 from dtos import (STATUS_ERROR, STATUS_OK, ChallengeResolutionResultT,
                   ChallengeResolutionT, HealthResponse, IndexResponse,
@@ -333,6 +334,62 @@ def _resolve_turnstile_captcha(req: V1RequestBase, driver: WebDriver):
             logging.debug(f'Turnstile challenge not found')
     return turnstile_token
 
+
+def _solve_captcha_if_present(req: V1RequestBase, driver: WebDriver, attempted: set):
+    """Detect a captcha on the current page and solve it with the configured solver.
+
+    Returns a dict ``{'type': str, 'token': str}`` when a captcha was solved and
+    its token injected into the page, or ``None`` when no solver is configured or
+    no supported captcha with a usable site key is present. Each site key is only
+    submitted to the solver once (tracked in ``attempted``) to avoid paying for
+    and re-injecting the same captcha on every retry.
+    """
+    solver = captcha.get_solver()
+    if solver is None:
+        return None
+
+    try:
+        facts = driver.execute_script(captcha.CAPTCHA_DETECT_JS)
+    except Exception as e:
+        logging.debug(f"Captcha detection script failed: {e}")
+        return None
+
+    detected = captcha.detect_captcha(facts, driver.current_url)
+    if detected is None:
+        return None
+
+    ctype = detected["type"]
+    sitekey = detected["sitekey"]
+    if sitekey in attempted:
+        return None
+    attempted.add(sitekey)
+
+    url = driver.current_url
+    useragent = utils.USER_AGENT or utils.get_user_agent(driver)
+    logging.info(f"{ctype} captcha detected (sitekey={sitekey}); "
+                 f"solving with the configured captcha solver...")
+
+    try:
+        if ctype == captcha.TURNSTILE:
+            token = solver.solve_turnstile(url=url, sitekey=sitekey,
+                                           action=detected.get("action"),
+                                           data=detected.get("data"),
+                                           useragent=useragent)
+        elif ctype == captcha.HCAPTCHA:
+            token = solver.solve_hcaptcha(url=url, sitekey=sitekey)
+        else:  # captcha.RECAPTCHA
+            token = solver.solve_recaptcha(url=url, sitekey=sitekey,
+                                           version=detected.get("version", "v2"),
+                                           action=detected.get("action"))
+    except Exception as e:
+        raise Exception(f"Error solving the {ctype} captcha with the configured solver. {e}")
+
+    logging.info(f"{ctype} captcha solved; injecting the token into the page.")
+    driver.execute_script(captcha.CAPTCHA_INJECT_JS[ctype], token)
+    time.sleep(2)
+    return {"type": ctype, "token": token}
+
+
 def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> ChallengeResolutionT:
     res = ChallengeResolutionT({})
     res.status = STATUS_OK
@@ -422,6 +479,10 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
                 logging.info("Challenge detected. Selector found: " + selector)
                 break
 
+    # site keys already submitted to the captcha solver (avoid paying twice)
+    attempted_captchas = set()
+    solved_captcha = None
+
     attempt = 0
     if challenge_found:
         while True:
@@ -444,7 +505,13 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
             except TimeoutException:
                 logging.debug("Timeout waiting for selector")
 
-                click_verify(driver)
+                # if a captcha solver is configured and a captcha is present,
+                # solve it automatically; otherwise fall back to clicking.
+                captcha_result = _solve_captcha_if_present(req, driver, attempted_captchas)
+                if captcha_result is not None:
+                    solved_captcha = captcha_result
+                else:
+                    click_verify(driver)
 
                 # update the html (cloudflare reloads the page every 5 s)
                 html_element = driver.find_element(By.TAG_NAME, "html")
@@ -460,8 +527,20 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
         logging.info("Challenge solved!")
         res.message = "Challenge solved!"
     else:
-        logging.info("Challenge not detected!")
-        res.message = "Challenge not detected!"
+        # no JS challenge was detected, but the page itself may be a bare
+        # captcha (hCaptcha / reCAPTCHA / Turnstile widget) we can solve.
+        solved_captcha = _solve_captcha_if_present(req, driver, attempted_captchas)
+        if solved_captcha is not None:
+            logging.info("Captcha solved!")
+            res.message = "Captcha solved!"
+        else:
+            logging.info("Challenge not detected!")
+            res.message = "Challenge not detected!"
+
+    # expose the token from an automatically solved captcha
+    if solved_captcha is not None:
+        if solved_captcha["type"] == captcha.TURNSTILE and not turnstile_token:
+            turnstile_token = solved_captcha["token"]
 
     challenge_res = ChallengeResolutionResultT({})
     challenge_res.url = driver.current_url
@@ -469,6 +548,8 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
     challenge_res.cookies = driver.get_cookies()
     challenge_res.userAgent = utils.get_user_agent(driver)
     challenge_res.turnstile_token = turnstile_token
+    if solved_captcha is not None:
+        challenge_res.captcha = {"type": solved_captcha["type"], "token": solved_captcha["token"]}
 
     if not req.returnOnlyCookies:
         challenge_res.headers = {}  # todo: fix, selenium not provides this info

--- a/src/tests_captcha.py
+++ b/src/tests_captcha.py
@@ -1,0 +1,258 @@
+"""Offline unit tests for the captcha-solver integration.
+
+These tests do not require a browser or network access. They cover the pure
+detection logic (:func:`captcha.detect_captcha`), the adapter loader
+(:func:`captcha.get_solver`) and the 2captcha adapter's type mapping (with a
+fake 2captcha client).
+
+Run with::
+
+    python -m unittest tests_captcha        # from the src/ directory
+"""
+import os
+import unittest
+from unittest import mock
+
+import captcha
+from captcha import TURNSTILE, HCAPTCHA, RECAPTCHA
+
+
+class TestDetectCaptcha(unittest.TestCase):
+
+    def test_none_when_empty(self):
+        self.assertIsNone(captcha.detect_captcha({}))
+        self.assertIsNone(captcha.detect_captcha(None))
+
+    def test_turnstile_widget(self):
+        facts = {"turnstileWidgets": [{"sitekey": "0xAAAA", "action": "login", "cdata": "abc"}]}
+        result = captcha.detect_captcha(facts)
+        self.assertEqual(result["type"], TURNSTILE)
+        self.assertEqual(result["sitekey"], "0xAAAA")
+        self.assertEqual(result["action"], "login")
+        self.assertEqual(result["data"], "abc")
+
+    def test_turnstile_from_iframe(self):
+        facts = {
+            "hasTurnstileResponse": True,
+            "iframeSrcs": [
+                "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/"
+                "turnstile/if/ov2/av0/rcv/0x4AAAAAAABkMYinukE8nzYS/light/normal"
+            ],
+        }
+        result = captcha.detect_captcha(facts)
+        self.assertEqual(result["type"], TURNSTILE)
+        self.assertEqual(result["sitekey"], "0x4AAAAAAABkMYinukE8nzYS")
+
+    def test_hcaptcha_widget(self):
+        facts = {"hcaptchaWidgets": [{"sitekey": "10000000-ffff-ffff-ffff-000000000001"}]}
+        result = captcha.detect_captcha(facts)
+        self.assertEqual(result["type"], HCAPTCHA)
+        self.assertEqual(result["sitekey"], "10000000-ffff-ffff-ffff-000000000001")
+
+    def test_hcaptcha_from_iframe(self):
+        facts = {
+            "hasHcaptchaResponse": True,
+            "iframeSrcs": ["https://newassets.hcaptcha.com/captcha/v1/foo/static/"
+                           "hcaptcha.html#frame=challenge&id=x&sitekey=abcd-123&theme=light"],
+        }
+        result = captcha.detect_captcha(facts)
+        self.assertEqual(result["type"], HCAPTCHA)
+        self.assertEqual(result["sitekey"], "abcd-123")
+
+    def test_recaptcha_v2_widget(self):
+        facts = {"recaptchaWidgets": [{"sitekey": "6Lc_key", "action": None}]}
+        result = captcha.detect_captcha(facts)
+        self.assertEqual(result["type"], RECAPTCHA)
+        self.assertEqual(result["sitekey"], "6Lc_key")
+        self.assertEqual(result["version"], "v2")
+
+    def test_recaptcha_v3_widget(self):
+        facts = {"recaptchaWidgets": [{"sitekey": "6Lc_key", "action": "homepage"}]}
+        result = captcha.detect_captcha(facts)
+        self.assertEqual(result["type"], RECAPTCHA)
+        self.assertEqual(result["version"], "v3")
+        self.assertEqual(result["action"], "homepage")
+
+    def test_recaptcha_from_iframe(self):
+        facts = {
+            "hasRecaptchaResponse": True,
+            "iframeSrcs": ["https://www.google.com/recaptcha/api2/anchor?ar=1&k=6LcSITEKEY&co=abc"],
+        }
+        result = captcha.detect_captcha(facts)
+        self.assertEqual(result["type"], RECAPTCHA)
+        self.assertEqual(result["sitekey"], "6LcSITEKEY")
+
+    def test_priority_turnstile_over_others(self):
+        facts = {
+            "turnstileWidgets": [{"sitekey": "0xTS"}],
+            "hcaptchaWidgets": [{"sitekey": "hc"}],
+            "recaptchaWidgets": [{"sitekey": "rc"}],
+        }
+        self.assertEqual(captcha.detect_captcha(facts)["type"], TURNSTILE)
+
+    def test_widget_without_sitekey_is_ignored(self):
+        facts = {"turnstileWidgets": [{"sitekey": None}], "hasTurnstileResponse": True,
+                 "iframeSrcs": []}
+        self.assertIsNone(captcha.detect_captcha(facts))
+
+
+class TestSolverLoader(unittest.TestCase):
+
+    def setUp(self):
+        captcha._SOLVER_CACHE.clear()
+
+    def tearDown(self):
+        captcha._SOLVER_CACHE.clear()
+
+    def test_config_none(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(captcha.get_config_captcha_solver())
+        with mock.patch.dict(os.environ, {"CAPTCHA_SOLVER": "none"}):
+            self.assertIsNone(captcha.get_config_captcha_solver())
+        with mock.patch.dict(os.environ, {"CAPTCHA_SOLVER": "2captcha"}):
+            self.assertEqual(captcha.get_config_captcha_solver(), "2captcha")
+
+    def test_get_solver_returns_none_when_unset(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(captcha.get_solver())
+
+    def test_get_solver_unknown_adapter_raises(self):
+        with mock.patch.dict(os.environ, {"CAPTCHA_SOLVER": "does_not_exist"}):
+            with self.assertRaises(Exception):
+                captcha.get_solver()
+
+    def test_get_solver_2captcha_requires_api_key(self):
+        with mock.patch.dict(os.environ, {"CAPTCHA_SOLVER": "2captcha"}, clear=True):
+            with self.assertRaises(Exception):
+                captcha.get_solver()
+
+    def test_get_solver_2captcha_loads_and_maps_types(self):
+        env = {"CAPTCHA_SOLVER": "2captcha", "TWOCAPTCHA_API_KEY": "test-key"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            solver = captcha.get_solver()
+            self.assertIsNotNone(solver)
+
+            # replace the real 2captcha network client with a fake
+            calls = {}
+
+            class FakeClient:
+                def turnstile(self, **kwargs):
+                    calls["turnstile"] = kwargs
+                    return {"captchaId": "1", "code": "ts-token"}
+
+                def hcaptcha(self, **kwargs):
+                    calls["hcaptcha"] = kwargs
+                    return {"captchaId": "2", "code": "hc-token"}
+
+                def recaptcha(self, **kwargs):
+                    calls["recaptcha"] = kwargs
+                    return {"captchaId": "3", "code": "rc-token"}
+
+            solver._client = FakeClient()
+
+            self.assertEqual(
+                solver.solve_turnstile(url="http://x", sitekey="0xTS", action="a",
+                                       data="d", useragent="UA"),
+                "ts-token")
+            self.assertEqual(calls["turnstile"]["sitekey"], "0xTS")
+            self.assertEqual(calls["turnstile"]["action"], "a")
+            self.assertEqual(calls["turnstile"]["useragent"], "UA")
+
+            self.assertEqual(solver.solve_hcaptcha(url="http://x", sitekey="hc"), "hc-token")
+            self.assertEqual(calls["hcaptcha"]["sitekey"], "hc")
+
+            self.assertEqual(
+                solver.solve_recaptcha(url="http://x", sitekey="rc", version="v3", action="home"),
+                "rc-token")
+            self.assertEqual(calls["recaptcha"]["version"], "v3")
+
+    def test_get_solver_is_cached(self):
+        env = {"CAPTCHA_SOLVER": "2captcha", "TWOCAPTCHA_API_KEY": "test-key"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertIs(captcha.get_solver(), captcha.get_solver())
+
+
+class FakeDriver:
+    """Minimal stand-in for a Selenium WebDriver used by the service tests."""
+
+    def __init__(self, facts, url="http://example.test/"):
+        self._facts = facts
+        self.current_url = url
+        self.injected = []
+
+    def execute_script(self, script, *args):
+        if script == captcha.CAPTCHA_DETECT_JS:
+            return self._facts
+        self.injected.append((script, args))
+        return None
+
+
+class TestServiceIntegration(unittest.TestCase):
+    """Exercise the wiring in flaresolverr_service without a browser."""
+
+    def setUp(self):
+        import utils
+        import flaresolverr_service as svc
+        from dtos import V1RequestBase
+        self.svc = svc
+        self.V1RequestBase = V1RequestBase
+        utils.USER_AGENT = "test-user-agent"  # avoid spawning a real webdriver
+        self._sleep_patch = mock.patch("flaresolverr_service.time.sleep")
+        self._sleep_patch.start()
+
+    def tearDown(self):
+        self._sleep_patch.stop()
+
+    def test_no_solver_configured_returns_none(self):
+        driver = FakeDriver({"turnstileWidgets": [{"sitekey": "0xTS"}]})
+        with mock.patch.object(captcha, "get_solver", return_value=None):
+            result = self.svc._solve_captcha_if_present(self.V1RequestBase({}), driver, set())
+        self.assertIsNone(result)
+        self.assertEqual(driver.injected, [])
+
+    def test_turnstile_solved_and_injected(self):
+        facts = {"turnstileWidgets": [{"sitekey": "0xTS", "action": None, "cdata": None}]}
+        driver = FakeDriver(facts)
+        fake_solver = mock.Mock()
+        fake_solver.solve_turnstile.return_value = "ts-token"
+        with mock.patch.object(captcha, "get_solver", return_value=fake_solver):
+            result = self.svc._solve_captcha_if_present(self.V1RequestBase({}), driver, set())
+        self.assertEqual(result, {"type": TURNSTILE, "token": "ts-token"})
+        fake_solver.solve_turnstile.assert_called_once()
+        self.assertIn(captcha.CAPTCHA_INJECT_JS[TURNSTILE], [s for s, _ in driver.injected])
+        self.assertIn(("ts-token",), [a for _, a in driver.injected])
+
+    def test_hcaptcha_solved_and_injected(self):
+        facts = {"hcaptchaWidgets": [{"sitekey": "hc-key"}]}
+        driver = FakeDriver(facts)
+        fake_solver = mock.Mock()
+        fake_solver.solve_hcaptcha.return_value = "hc-token"
+        with mock.patch.object(captcha, "get_solver", return_value=fake_solver):
+            result = self.svc._solve_captcha_if_present(self.V1RequestBase({}), driver, set())
+        self.assertEqual(result["type"], HCAPTCHA)
+        fake_solver.solve_hcaptcha.assert_called_once_with(url="http://example.test/", sitekey="hc-key")
+
+    def test_same_sitekey_not_submitted_twice(self):
+        facts = {"turnstileWidgets": [{"sitekey": "0xTS"}]}
+        driver = FakeDriver(facts)
+        fake_solver = mock.Mock()
+        fake_solver.solve_turnstile.return_value = "ts-token"
+        attempted = set()
+        with mock.patch.object(captcha, "get_solver", return_value=fake_solver):
+            first = self.svc._solve_captcha_if_present(self.V1RequestBase({}), driver, attempted)
+            second = self.svc._solve_captcha_if_present(self.V1RequestBase({}), driver, attempted)
+        self.assertIsNotNone(first)
+        self.assertIsNone(second)
+        fake_solver.solve_turnstile.assert_called_once()
+
+    def test_no_captcha_present_returns_none(self):
+        driver = FakeDriver({"iframeSrcs": []})
+        fake_solver = mock.Mock()
+        with mock.patch.object(captcha, "get_solver", return_value=fake_solver):
+            result = self.svc._solve_captcha_if_present(self.V1RequestBase({}), driver, set())
+        self.assertIsNone(result)
+        fake_solver.solve_turnstile.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

FlareSolverr documents a `CAPTCHA_SOLVER` environment variable and a `/captcha` adapters directory, but the Python rewrite (v3.0) shipped without any solver implementation — the README still notes that *"none of the captcha solvers work"*.

This PR restores that capability with a small, pluggable solver framework and a **2captcha** adapter that automatically solves **Cloudflare Turnstile**, **hCaptcha** and **reCAPTCHA v2/v3**.

## How it works

- A solver is an adapter module in `src/captcha/`, selected with `CAPTCHA_SOLVER` (the file name, e.g. `2captcha`). Unset / `none` keeps the previous behaviour.
- During challenge resolution (and on bare captcha pages), FlareSolverr detects a supported captcha, extracts the site key, sends it to the configured solver, and injects the returned token into the page (triggering the widget callback). The solved page (cookies + HTML) is returned as usual, and the token is exposed under `solution.captcha` (plus `solution.turnstile_token` for Turnstile).
- The 2captcha adapter wraps the official `2captcha-python` library and reads `TWOCAPTCHA_API_KEY`.

## Configuration

```
CAPTCHA_SOLVER=2captcha
TWOCAPTCHA_API_KEY=<key>
```

Tip: raise the request `maxTimeout` (e.g. `120000`) so the external solver has time to return a token.

## Testing

- Added offline unit/integration tests in `src/tests_captcha.py` (detection, adapter loader, type mapping, and the service wiring with a fake driver) — 21 tests, all passing.
- Verified end-to-end from the Docker image against a live reCAPTCHA page: FlareSolverr detected the captcha, solved it via 2captcha, injected the token and returned `Captcha solved!` with `solution.captcha` populated.

## Notes

- Adds `2captcha-python` to `requirements.txt`.
- The Cloudflare *managed challenge* interstitial (no exposed `data-sitekey`) is out of scope for a site-key-only solve; standalone widgets are supported.
- Writing another adapter only requires a `get_solver()` returning a `CaptchaSolver` implementation.
