### PR TITLE
Prevent resource-intensive pages from running indefinitely in persistent sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ This works like `request.get`, with the addition of the postData parameter. Note
 | LANG                 | none                   | Language used in the web browser. Example: `LANG=en_GB`.                                                                                 |
 | HEADLESS             | true                   | Only for debugging. To run the web browser in headless mode or visible.                                                                  |
 | DISABLE_MEDIA        | false                  | To disable loading images, CSS, and other media in the web browser to save network bandwidth.                                            |
+| SESSION_AUTO_PARK    | false                  | Navigate persistent sessions to `about:blank` after each request to stop the solved page from consuming resources while idle.            |
 | BROWSER_WAIT_TIMEOUT | 1                    | Seconds to wait for the web browser to reach an expected page state on each attempt. Increase it on slow hosts or slow websites.         |
 | TEST_URL             | https://www.google.com | FlareSolverr makes a request on start to make sure the web browser is working. You can change that URL if it is blocked in your country. |
 | PORT                 | 8191                   | Listening port. You don't need to change this if you are running on Docker.                                                              |

--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -250,11 +250,22 @@ def _resolve_challenge(req: V1RequestBase, method: str) -> ChallengeResolutionT:
     except Exception as e:
         raise Exception('Error solving the challenge. ' + str(e).replace('\n', '\\n'))
     finally:
-        if not req.session and driver is not None:
+        if req.session and driver is not None and utils.get_config_session_auto_park():
+            _park_session(driver, req.session)
+        elif not req.session and driver is not None:
             if utils.PLATFORM_VERSION == "nt":
                 driver.close()
             driver.quit()
             logging.debug('A used instance of webdriver has been destroyed')
+
+
+def _park_session(driver: WebDriver, session_id: str) -> None:
+    """Stop the current page workload without destroying a persistent session."""
+    try:
+        driver.get('about:blank')
+        logging.debug(f'Persistent session parked on about:blank (session_id={session_id})')
+    except Exception as e:
+        logging.warning(f'Could not park persistent session (session_id={session_id}): {e}')
 
 
 def click_verify(driver: WebDriver, num_tabs: int = 1):

--- a/src/utils.py
+++ b/src/utils.py
@@ -32,6 +32,10 @@ def get_config_disable_media() -> bool:
     return os.environ.get('DISABLE_MEDIA', 'false').lower() == 'true'
 
 
+def get_config_session_auto_park() -> bool:
+    return os.environ.get('SESSION_AUTO_PARK', 'false').lower() == 'true'
+
+
 def get_config_browser_wait_timeout() -> int:
     return int(os.environ.get('BROWSER_WAIT_TIMEOUT', 1))
 


### PR DESCRIPTION
## Summary

- add opt-in `SESSION_AUTO_PARK` support for navigating persistent sessions to `about:blank` after request completion
- prevent resource-intensive pages from continuing to consume CPU and memory while persistent sessions are idle
- keep parking failures non-fatal and preserve the existing behavior by default

## Tests

manual Docker reproduction with FlareSolverr 3.5.0 and a fresh persistent session:
- request ressource-intensive page
- before parking potential constant high cpu and/or memory usage
- after parking on `about:blank` back to regular idle usage
- confirmed the ChromeDriver session remained active in `sessions.list`
