### PR TITLE
Emit --disable-features once instead of letting the second discard the first

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -153,8 +153,14 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
         options.add_argument('--disable-gpu-sandbox')
     options.add_argument('--ignore-certificate-errors')
     options.add_argument('--ignore-ssl-errors')
-    # disable breaking popup
-    options.add_argument("--disable-features=LocalNetworkAccessChecks")
+
+    # Chrome parses --disable-features as a single value: passing the switch a
+    # second time keeps the last value and silently discards the earlier one
+    # whole, along with every feature it named. Collect the names here and emit
+    # one switch once, below, after every branch that may add to them.
+    disabled_features = [
+        'LocalNetworkAccessChecks',  # disable breaking popup
+    ]
 
     language = os.environ.get('LANG', None)
     if language is not None:
@@ -167,12 +173,14 @@ def get_webdriver(proxy: dict = None) -> WebDriver:
     proxy_extension_dir = None
     if proxy and all(key in proxy for key in ['url', 'username', 'password']):
         proxy_extension_dir = create_proxy_extension(proxy)
-        options.add_argument("--disable-features=DisableLoadExtensionCommandLineSwitch")
+        disabled_features.append('DisableLoadExtensionCommandLineSwitch')
         options.add_argument("--load-extension=%s" % os.path.abspath(proxy_extension_dir))
     elif proxy and 'url' in proxy:
         proxy_url = proxy['url']
         logging.debug("Using webdriver proxy: %s", proxy_url)
         options.add_argument('--proxy-server=%s' % proxy_url)
+
+    options.add_argument('--disable-features=%s' % ','.join(disabled_features))
 
     # note: headless mode is detected (headless = True)
     # we launch the browser in head-full mode with the window hidden


### PR DESCRIPTION
## What is wrong

`get_webdriver` builds its Chrome arguments with two separate
`--disable-features` switches:

- `--disable-features=LocalNetworkAccessChecks`, unconditionally, commented
  `# disable breaking popup`
- `--disable-features=DisableLoadExtensionCommandLineSwitch`, added only when the
  configured proxy carries a username and a password, so the generated auth
  extension can be loaded

Chrome does not accumulate `--disable-features`. It parses the switch as a single
value, and a later occurrence replaces an earlier one outright, so on the
authenticated-proxy path the second switch discards the first and
`LocalNetworkAccessChecks` is never disabled. The popup that the first switch
exists to suppress comes back - for exactly the users running an authenticated
proxy, and for nobody else.

`undetected_chromedriver` does not merge the two on the way through: it strips
`--headless`, reads `lang`, and passes the remaining arguments in order. Nothing
downstream repairs this.

## The measurement

Chrome 151.0.7922.34. The indicator is a `base::Feature` that gates a JavaScript
property, which keeps the whole thing offline: disable the feature and
`window.documentPictureInPicture` stops existing. `F` is
`DocumentPictureInPictureAPI` and `X` is `LocalNetworkAccessChecks`. Each arm was
launched twice with a fresh profile, and the two runs agreed on every arm.

| command line | `documentPictureInPicture` | reading |
|---|---|---|
| `--disable-features=F` | absent | the indicator works |
| `--disable-features=F` `--disable-features=X` | **present** | the first switch was discarded |
| `--disable-features=X` `--disable-features=F` | absent | the last switch wins |
| `--disable-features=F,X` | absent | one switch, both names: the fix |
| `--disable-features=F` `--disable-features=<unknown name>` | **present** | the second switch does not have to name anything real |

Row three is the control that makes row two mean what it says: `X` is on the
command line there too and `F` is still applied, so "the second switch discarded
the first" is not interchangeable with "`X` re-enabled `F`".

Row three is also this repository's actual order, which is why the bug is
invisible in practice. The surviving switch is the one added last, so the auth
extension does load and the proxy works. The casualty is the other feature, and
nothing reports it.

Row five matters for a specific reason. `DisableLoadExtensionCommandLineSwitch`
does not occur even once in the Chromium 151 binary - a scan of `chrome.dll` and
`chrome.exe` for the feature literal puts it at 0, against `Translate` at 59 and
a name nobody has implemented at 0 as controls. A reasonable objection is
therefore that the second switch here names nothing and might be inert. It is
not: a switch whose value matches no feature at all still discards the earlier
switch whole. Whether that name is live in the Chrome this project actually
drives does not change the outcome for `LocalNetworkAccessChecks`.

`LocalNetworkAccessChecks` itself is present in the binary, so the switch this
patch rescues is doing real work when it survives.

**Measured and inferred, kept apart.** The command-line parsing above is
measured, on the arms shown, twice each. That `LocalNetworkAccessChecks` is
consequently not disabled in FlareSolverr follows from that plus the order in the
source; I have not reproduced the popup itself, which would need a live
authenticated proxy and a site that triggers a local network access check. If the
popup has some other cause, merging the switches is still correct, but the
user-visible symptom would differ from the one described here.

## The change

Collect the feature names in a list and emit a single `--disable-features=`
argument after every branch that can contribute to it, instead of appending a
second switch. The unauthenticated path is unaffected - it only ever had one
switch. On the authenticated path both features now take effect.

`browser-use` does the same thing in `get_args()`, with a comment saying it is
what stops one option from silently breaking another, if a reference
implementation is useful.

## What I did not run

`src/tests.py` and `src/tests_sites.py` drive live Google, httpbin,
Cloudflare-protected and DDoS-Guard-protected endpoints. This host reaches the
network through a VPN gateway, so any pass or fail from those suites here would
say more about the gateway than about the patch, and quoting a result from them
would be misleading. The change is confined to how arguments are assembled before
launch, and the assembly is what the table above measures. Happy to run them on a
clean connection, or to add a unit test asserting a single `--disable-features`
in the built argument list, if either is wanted.

## Not in this PR

Any other duplicate switch. This is the only place in `get_webdriver` where two
`--disable-features` are emitted, and widening this into defensive merging across
the whole argument list would be a larger change than the bug calls for.
