### PR TITLE
Fail on the DDoS-Guard captcha page instead of reporting a solved challenge

### DIFF
--- a/src/flaresolverr_service.py
+++ b/src/flaresolverr_service.py
@@ -12,7 +12,7 @@ from selenium.webdriver.chrome.webdriver import WebDriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.expected_conditions import (
-    presence_of_element_located, staleness_of, title_is)
+    presence_of_element_located, staleness_of)
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support.wait import WebDriverWait
 
@@ -46,7 +46,15 @@ CHALLENGE_SELECTORS = [
     # Custom CloudFlare for EbookParadijs, Film-Paleis, MuziekFabriek and Puur-Hollands
     'td.info #js_info',
     # Fairlane / pararius.com
-    'div.vc div.text-box h2'
+    'div.vc div.text-box h2',
+    # DDoS-Guard js-challenge interstitial
+    'script[src*="/.well-known/ddos-guard/js-challenge/"]'
+]
+CAPTCHA_PAGE_SELECTORS = [
+    # DDoS-Guard manual captcha page, served at ?check=1 when the automated js-challenge
+    # rejects the browser or IP. FlareSolverr cannot solve it, so fail loudly instead of
+    # returning it as a solved challenge.
+    'script[src*="/.well-known/ddos-guard/ddg-captcha-page/"]'
 ]
 
 TURNSTILE_SELECTORS = [
@@ -338,6 +346,30 @@ def _resolve_turnstile_captcha(req: V1RequestBase, driver: WebDriver):
             logging.debug(f'Turnstile challenge not found')
     return turnstile_token
 
+class _title_matches_ignoring_case:
+    """A case-insensitive title-match wait condition.
+
+    Challenge detection compares titles case-insensitively, so the wait that clears the
+    challenge must too: DDoS-Guard changes its title from "DDoS-Guard" to "DDOS-GUARD"
+    when it escalates to its manual captcha page, and a case-sensitive wait mistakes that
+    flip for a solved challenge.
+    """
+
+    def __init__(self, title: str):
+        self.title = title.lower()
+
+    def __call__(self, driver) -> bool:
+        return driver.title.lower() == self.title
+
+
+def _raise_if_captcha_page(driver: WebDriver) -> None:
+    for selector in CAPTCHA_PAGE_SELECTORS:
+        if len(driver.find_elements(By.CSS_SELECTOR, selector)) > 0:
+            raise Exception('DDoS-Guard returned its manual captcha page: the automated '
+                            'browser check failed for this IP and browser, and FlareSolverr '
+                            'cannot solve captchas.')
+
+
 def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> ChallengeResolutionT:
     res = ChallengeResolutionT({})
     res.status = STATUS_OK
@@ -410,6 +442,8 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
         if len(found_elements) > 0:
             raise Exception('Cloudflare has blocked this request. '
                             'Probably your IP is banned for this site, check in your web browser.')
+    # a repeat visit from a flagged IP can land directly on the DDoS-Guard captcha page
+    _raise_if_captcha_page(driver)
 
     # find challenge by title
     challenge_found = False
@@ -436,7 +470,7 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
                 # wait until the title changes
                 for title in CHALLENGE_TITLES:
                     logging.debug("Waiting for title (attempt " + str(attempt) + "): " + title)
-                    WebDriverWait(driver, browser_wait_timeout).until_not(title_is(title))
+                    WebDriverWait(driver, browser_wait_timeout).until_not(_title_matches_ignoring_case(title))
 
                 # then wait until all the selectors disappear
                 for selector in CHALLENGE_SELECTORS:
@@ -450,6 +484,9 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
             except TimeoutException:
                 logging.debug("Timeout waiting for selector")
 
+                # the js-challenge can escalate to a manual captcha mid-wait
+                _raise_if_captcha_page(driver)
+
                 click_verify(driver)
 
                 # update the html (cloudflare reloads the page every 5 s)
@@ -462,6 +499,9 @@ def _evil_logic(req: V1RequestBase, driver: WebDriver, method: str) -> Challenge
             WebDriverWait(driver, browser_wait_timeout).until(staleness_of(html_element))
         except Exception:
             logging.debug("Timeout waiting for redirect")
+
+        # never report the DDoS-Guard captcha page as a solved challenge
+        _raise_if_captcha_page(driver)
 
         logging.info("Challenge solved!")
         res.message = "Challenge solved!"


### PR DESCRIPTION
## Problem

FlareSolverr silently returns the DDoS-Guard **manual captcha page** as a solved
challenge. When DDoS-Guard rejects a client, it escalates the automatic `js-challenge`
interstitial to a `ddg-captcha-page` served at `?check=1`. Two bugs combine so this is
reported as success:

1. Challenge **detection** is title-only for DDoS-Guard (`CHALLENGE_TITLES` has
   `'DDoS-Guard'`, but `CHALLENGE_SELECTORS` has no DDoS-Guard entry). The captcha page's
   title is `DDOS-GUARD` (uppercase). Detection is case-insensitive and matches, so a
   challenge *is* detected.
2. The clear-wait uses `title_is(title)`, which is **case-sensitive**. It waits for the
   title to differ from `"DDoS-Guard"`; the captcha title `"DDOS-GUARD"` already differs,
   so `until_not` returns immediately, the js-challenge selectors aren't present on the
   captcha page, and the loop breaks with `"Challenge solved!"` — returning the captcha
   HTML. Callers then parse an empty/garbage result as real data.

## Fix

- Add a DDoS-Guard js-challenge **selector** so detection doesn't hinge on the exact
  title string.
- Make the title-clear wait **case-insensitive** (`_title_matches_ignoring_case`), so the
  `DDoS-Guard` → `DDOS-GUARD` flip is not mistaken for a solved challenge.
- Add `CAPTCHA_PAGE_SELECTORS` + `_raise_if_captcha_page()` and check it in three places
  (before detection, on each timeout cycle, and before declaring success), so an
  unsolvable captcha page raises a clear error instead of a false success.

## Verification

- **Cloudflare regression:** a Cloudflare-protected site still solves — no behavioural
  change on the Cloudflare path.
- **DDoS-Guard solve path:** `litres.ru` (the DDoS-Guard URL already used by this repo's
  own test suite) still returns the full page with `__ddg*` cookies.
- **DDoS-Guard captcha escalation:** against a DDoS-Guard site that escalates to the
  captcha page for a rejected client, the request now raises
  `"DDoS-Guard returned its manual captcha page ... cannot solve captchas"` instead of the
  previous silent `status: ok` / `"Challenge solved!"` carrying the captcha page as the
  response body.